### PR TITLE
Sharing: transfer policy core (context → policy → policy_result → action)

### DIFF
--- a/common/luaUtilities/team_transfer/context_factory.lua
+++ b/common/luaUtilities/team_transfer/context_factory.lua
@@ -1,0 +1,169 @@
+local TransferEnums = VFS.Include("common/luaUtilities/team_transfer/transfer_enums.lua")
+local TeamResourceData = VFS.Include("common/luaUtilities/team_transfer/team_resource_data.lua")
+
+---@alias PolicyContextEnricher fun(ctx: PolicyContext, springRepo: SpringSynced, senderTeamID: number, receiverTeamID: number)
+
+---@class ContextFactory
+---@field create fun(springRepo: SpringSynced): ContextFactory
+---@field registerPolicyContextEnricher fun(fn: PolicyContextEnricher)
+---@field policy fun(senderTeamID: number, receiverTeamID: number): PolicyContext
+---@field action fun(senderTeamId: number, receiverTeamId: number, transferCategory: string): PolicyActionContext
+---@field resourceTransfer fun(senderTeamId: number, receiverTeamId: number, resourceType: ResourceName, desiredAmount: number, policyResult: ResourcePolicyResult): ResourceTransferContext
+---@field unitTransfer fun(senderTeamId: number, receiverTeamId: number, unitIds: number[], given: boolean, policyResult: UnitPolicyResult, unitValidationResult: UnitValidationResult): UnitTransferContext
+local ContextFactory = {}
+
+-- shared via GG because VFS.Include re-runs per call; a module-local list would split registrar and consumer into separate registries
+GG = GG or {}
+GG.policyContextEnrichers = GG.policyContextEnrichers or {}
+local enrichers = GG.policyContextEnrichers
+
+---@param fn PolicyContextEnricher
+function ContextFactory.registerPolicyContextEnricher(fn)
+  enrichers[#enrichers + 1] = fn
+end
+
+function ContextFactory.getEnrichers()
+  local copy = {}
+  for i = 1, #enrichers do copy[i] = enrichers[i] end
+  return copy
+end
+
+-- mutate in place so the shared reference (and create()'s closures) stay valid
+function ContextFactory.setEnrichers(list)
+  for i = #enrichers, 1, -1 do enrichers[i] = nil end
+  if list then
+    for i = 1, #list do enrichers[i] = list[i] end
+  end
+end
+
+---@param springRepo SpringSynced
+---@return table Context factory with closures
+function ContextFactory.create(springRepo)
+  -- per-snapshot resource memo so a refresh pass reads each team once, not once per pair; caller clears it at pass start
+  local resourceCache = {}
+
+  local function getResource(teamID, resourceType)
+    local perTeam = resourceCache[teamID]
+    if not perTeam then
+      perTeam = {}
+      resourceCache[teamID] = perTeam
+    end
+    local data = perTeam[resourceType]
+    if not data then
+      data = TeamResourceData.Get(springRepo, teamID, resourceType)
+      perTeam[resourceType] = data
+    end
+    return data
+  end
+
+  local function clearResourceCache()
+    resourceCache = {}
+  end
+
+  ---@param senderTeamID number
+  ---@param receiverTeamID number
+  ---@param extensions? table
+  ---@return table
+  local function buildContext(senderTeamID, receiverTeamID, extensions)
+    ---@type TeamResources
+    local senderResources = {
+      metal = getResource(senderTeamID, TransferEnums.ResourceType.METAL),
+      energy = getResource(senderTeamID, TransferEnums.ResourceType.ENERGY)
+    }
+
+    ---@type TeamResources
+    local receiverResources = {
+      metal = getResource(receiverTeamID, TransferEnums.ResourceType.METAL),
+      energy = getResource(receiverTeamID, TransferEnums.ResourceType.ENERGY)
+    }
+
+    ---@type PolicyContext
+    local ctx = {
+      senderTeamId = senderTeamID,
+      receiverTeamId = receiverTeamID,
+      sender = senderResources,
+      receiver = receiverResources,
+      springRepo = springRepo,
+      areAlliedTeams = springRepo.AreTeamsAllied(senderTeamID, receiverTeamID) == true,
+      isCheatingEnabled = springRepo.IsCheatingEnabled(),
+      ext = {},
+    }
+
+    for _, enricher in ipairs(enrichers) do
+      enricher(ctx, springRepo, senderTeamID, receiverTeamID)
+    end
+
+    if extensions then
+      for k, v in pairs(extensions) do
+        ctx[k] = v
+      end
+    end
+
+    return ctx
+  end
+
+  ---@param senderTeamID number
+  ---@param receiverTeamID number
+  ---@param commandType? string
+  ---@return PolicyContext
+  local function policy(senderTeamID, receiverTeamID, commandType)
+    return buildContext(senderTeamID, receiverTeamID, {
+      commandType = commandType
+    })
+  end
+
+  ---@param transferCategory string
+  ---@param senderTeamId number
+  ---@param receiverTeamId number
+  ---@return PolicyActionContext
+  local function policyAction(senderTeamId, receiverTeamId, transferCategory)
+    return buildContext(senderTeamId, receiverTeamId, {
+      transferCategory = transferCategory
+    })
+  end
+
+  ---@param senderTeamId number
+  ---@param receiverTeamId number
+  ---@param resourceType ResourceName
+  ---@param desiredAmount number
+  ---@param policyResult ResourcePolicyResult
+  ---@return ResourceTransferContext
+  local function resourceTransfer(senderTeamId, receiverTeamId, resourceType, desiredAmount, policyResult)
+    local transferCategory = resourceType == TransferEnums.ResourceType.METAL and
+        TransferEnums.TransferCategory.MetalTransfer or
+        TransferEnums.TransferCategory.EnergyTransfer
+    return buildContext(senderTeamId, receiverTeamId, {
+      transferCategory = transferCategory,
+      resourceType = resourceType,
+      desiredAmount = desiredAmount,
+      policyResult = policyResult
+    })
+  end
+
+  ---@param senderTeamId number
+  ---@param receiverTeamId number
+  ---@param unitIds number[]
+  ---@param given boolean?
+  ---@param policyResult UnitPolicyResult
+  ---@param validationResult UnitValidationResult
+  ---@return UnitTransferContext
+  local function unitTransfer(senderTeamId, receiverTeamId, unitIds, given, policyResult, validationResult)
+    return buildContext(senderTeamId, receiverTeamId, {
+        transferCategory = TransferEnums.TransferCategory.UnitTransfer,
+        unitIds = unitIds,
+        given = given,
+        policyResult = policyResult,
+        validationResult = validationResult
+    })
+  end
+
+  return {
+    policy = policy,
+    action = policyAction,
+    resourceTransfer = resourceTransfer,
+    unitTransfer = unitTransfer,
+    clearResourceCache = clearResourceCache,
+  }
+end
+
+return ContextFactory

--- a/common/luaUtilities/team_transfer/resource_transfer_shared.lua
+++ b/common/luaUtilities/team_transfer/resource_transfer_shared.lua
@@ -1,0 +1,153 @@
+local TransferEnums = VFS.Include("common/luaUtilities/team_transfer/transfer_enums.lua")
+local PolicyShared = VFS.Include("common/luaUtilities/team_transfer/team_transfer_serialization_helpers.lua")
+local Comms = VFS.Include("common/luaUtilities/team_transfer/resource_transfer_comms.lua")
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+
+local Shared = Comms
+
+local FieldTypes = PolicyShared.FieldTypes
+
+-- Schema for the GUI's flattened per-player policy packing (gui_advplayerlist/policy.lua).
+Shared.ResourcePolicyFields = {
+  resourceType = FieldTypes.string,
+  canShare = FieldTypes.boolean,
+  amountSendable = FieldTypes.number,
+  amountReceivable = FieldTypes.number,
+  taxedPortion = FieldTypes.number,
+  taxRate = FieldTypes.number,
+}
+
+-- one factor record per (team, resource), O(teams); GetCachedPolicyResult rebuilds any pair on read via min(taxedSendable(sender), capacity(receiver))
+Shared.ResourceFactorFields = {
+  taxedSendable = FieldTypes.number,
+  taxRate = FieldTypes.number,
+  capacity = FieldTypes.number,
+  isNonPlayer = FieldTypes.boolean,
+  active = FieldTypes.boolean,
+}
+
+---Rules-param key for a team's resource factor record (owner team = the rules-param team).
+---@param resourceType ResourceName
+---@return string
+function Shared.MakeFactorKey(resourceType)
+  local transferCategory = resourceType == TransferEnums.ResourceType.METAL and
+    TransferEnums.TransferCategory.MetalTransfer or TransferEnums.TransferCategory.EnergyTransfer
+  return transferCategory .. "_factor"
+end
+
+---@param factor table
+---@return string
+function Shared.SerializeResourceFactor(factor)
+  return PolicyShared.Serialize(Shared.ResourceFactorFields, factor)
+end
+
+---@param serialized string
+---@return table
+function Shared.DeserializeResourceFactor(serialized)
+  return PolicyShared.Deserialize(Shared.ResourceFactorFields, serialized)
+end
+
+---combine sender + receiver factors into a ResourcePolicyResult (same math as CalcResourcePolicy)
+---@param taxedSendable number sender factor
+---@param taxRate number sender factor
+---@param capacity number receiver factor
+---@param senderTeamId number
+---@param receiverTeamId number
+---@param resourceType ResourceName
+---@param result table? optional reusable result table
+---@return ResourcePolicyResult
+function Shared.CombineResourcePolicy(taxedSendable, taxRate, capacity, senderTeamId, receiverTeamId, resourceType, result)
+  result = result or {}
+  local taxedPortion = math.min(taxedSendable, capacity)
+  local amountSendable = taxedPortion
+  result.senderTeamId = senderTeamId
+  result.receiverTeamId = receiverTeamId
+  result.canShare = capacity > 0 and amountSendable > 0
+  result.amountSendable = amountSendable
+  result.amountReceivable = capacity
+  result.taxedPortion = taxedPortion
+  result.taxRate = taxRate
+  result.resourceType = resourceType
+  return result
+end
+
+---@param senderTeamId number
+---@param receiverTeamId number
+---@param resourceType ResourceName
+---@param springApi SpringSynced?
+---@return ResourcePolicyResult
+function Shared.CreateDenyPolicy(senderTeamId, receiverTeamId, resourceType, springApi)
+  ---@type ResourcePolicyResult
+  local result = {
+    senderTeamId = senderTeamId,
+    receiverTeamId = receiverTeamId,
+    canShare = false,
+    amountSendable = 0,
+    amountReceivable = 0,
+    taxedPortion = 0,
+    taxRate = 0,
+    resourceType = resourceType,
+  }
+  return result
+end
+
+---@param policyResult ResourcePolicyResult
+---@param desired number
+---@return number received, number sent
+function Shared.CalculateSenderTaxedAmount(policyResult, desired)
+  if desired <= 0 then
+    return 0, 0
+  end
+  local r = policyResult.taxRate
+  if r >= 1.0 then
+    -- 100% tax means the resource cannot be sent (infinite cost)
+    return 0, 0
+  end
+  local sent = desired / (1 - r)
+  return desired, sent
+end
+
+---@param spring SpringSynced
+---@param teamId number
+---@param resourceType ResourceName
+---@return table|nil factor record, or nil if not cached
+local function readFactor(spring, teamId, resourceType)
+  local serialized = spring.GetTeamRulesParam(teamId, Shared.MakeFactorKey(resourceType))
+  if serialized == nil then return nil end
+  return Shared.DeserializeResourceFactor(serialized)
+end
+
+---rebuild (sender,receiver) policy from cached factors + live gates (gate order mirrors TryDenyPolicy); absent factors deny
+---@param senderId number
+---@param receiverId number
+---@param resourceType ResourceName
+---@param springApi SpringSynced?
+---@return ResourcePolicyResult
+function Shared.GetCachedPolicyResult(senderId, receiverId, resourceType, springApi)
+  local spring = springApi or Spring
+  if not SharedConfig.isResourceSharingEnabled(spring) then
+    return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+  end
+
+  local senderFactor = readFactor(spring, senderId, resourceType)
+  local receiverFactor = readFactor(spring, receiverId, resourceType)
+  if not senderFactor or not receiverFactor then
+    return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+  end
+
+  if not spring.IsCheatingEnabled() then
+    if not spring.AreTeamsAllied(senderId, receiverId) and not senderFactor.isNonPlayer then
+      return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+    end
+    if not receiverFactor.active then
+      return Shared.CreateDenyPolicy(senderId, receiverId, resourceType, spring)
+    end
+  end
+
+  return Shared.CombineResourcePolicy(
+    senderFactor.taxedSendable, senderFactor.taxRate, receiverFactor.capacity,
+    senderId, receiverId, resourceType
+  )
+end
+
+return Shared

--- a/common/luaUtilities/team_transfer/resource_transfer_synced.lua
+++ b/common/luaUtilities/team_transfer/resource_transfer_synced.lua
@@ -1,0 +1,199 @@
+local SharedConfig = VFS.Include("common/luaUtilities/economy/shared_config.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/team_transfer/transfer_enums.lua")
+local Comms = VFS.Include("common/luaUtilities/team_transfer/resource_transfer_comms.lua")
+local Shared = VFS.Include("common/luaUtilities/team_transfer/resource_transfer_shared.lua")
+local WaterfillSolver = VFS.Include("common/luaUtilities/economy/economy_waterfill_solver.lua")
+local PolicyEvents = VFS.Include("common/luaUtilities/team_transfer/policy_events.lua")
+
+local ResourceType = TransferEnums.ResourceType
+local METAL = ResourceType.METAL
+local ENERGY = ResourceType.ENERGY
+
+local Gadgets = {
+  SendTransferChatMessages = Comms.SendTransferChatMessages,
+}
+
+local function isNonPlayerTeam(springRepo, teamId)
+  if teamId == springRepo.GetGaiaTeamID() then
+    return true
+  end
+  local _name, _active, _spec, isAiTeam = springRepo.GetTeamInfo(teamId, false)
+  if isAiTeam then
+    return true
+  end
+  -- Spring.GetTeamLuaAI returns "" (not nil) for teams without a LuaAI, so guard both.
+  local luaAI = springRepo.GetTeamLuaAI and springRepo.GetTeamLuaAI(teamId)
+  return luaAI ~= nil and luaAI ~= ""
+end
+
+-- Encapsulate legacy AllowResourceTransfer gate rules
+---@param ctx PolicyContext
+---@param resourceType ResourceName
+---@return ResourcePolicyResult|nil
+local function TryDenyPolicy(ctx, resourceType)
+  if not SharedConfig.isResourceSharingEnabled(ctx.springRepo) then
+    return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+  end
+
+  if ctx.isCheatingEnabled then
+    return nil
+  end
+
+  if not ctx.areAlliedTeams and not isNonPlayerTeam(ctx.springRepo, ctx.senderTeamId) then
+    return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+  end
+
+  local numActivePlayers = ctx.springRepo.GetTeamRulesParam(ctx.receiverTeamId, "numActivePlayers")
+  if numActivePlayers ~= nil and tonumber(numActivePlayers) == 0 then
+    return Shared.CreateDenyPolicy(ctx.senderTeamId, ctx.receiverTeamId, resourceType, ctx.springRepo)
+  end
+  return nil
+end
+
+--- Execute a resource transfer using received-unit desiredAmount capped by policy limits
+---@param ctx ResourceTransferContext
+---@return ResourceTransferResult
+function Gadgets.ResourceTransfer(ctx)
+  local policyResult = ctx.policyResult
+  local desiredAmount = ctx.desiredAmount
+  if (not policyResult or not policyResult.canShare) or (not desiredAmount or desiredAmount <= 0) then
+    ---@type ResourceTransferResult
+    return {
+      success = false,
+      sent = 0,
+      received = 0,
+      senderTeamId = ctx.senderTeamId,
+      receiverTeamId = ctx.receiverTeamId,
+      policyResult = policyResult,
+    }
+  end
+
+  local received, sent = Shared.CalculateSenderTaxedAmount(policyResult, desiredAmount)
+
+  local springRepo = ctx.springRepo
+  local resourceType = policyResult.resourceType
+  -- deduct via SetTeamResource; AddTeamResource clamps its amount to >= 0
+  local senderCurrent = springRepo.GetTeamResources(ctx.senderTeamId, resourceType)
+  springRepo.SetTeamResource(ctx.senderTeamId, resourceType, math.max(0, senderCurrent - sent))
+  springRepo.AddTeamResource(ctx.receiverTeamId, resourceType, received)
+
+  ---@type ResourceTransferResult
+  local result = {
+    success = true,
+    sent = sent,
+    received = received,
+    senderTeamId = ctx.senderTeamId,
+    receiverTeamId = ctx.receiverTeamId,
+    policyResult = policyResult
+  }
+
+  return result
+end
+
+local policyResultPool = {}
+
+---resolve a context's effective resource tax rate in [0,1] (sender tech tax, else base)
+---@param ctx PolicyContext
+---@return number
+local function resolveEffectiveRate(ctx)
+  local taxRate = ctx.taxRate or SharedConfig.getTaxConfig(ctx.springRepo)
+  return (taxRate < 1) and taxRate or 1
+end
+
+---@param ctx PolicyContext
+---@param resourceType ResourceName
+---@return ResourcePolicyResult
+function Gadgets.CalcResourcePolicy(ctx, resourceType)
+  local rejected = TryDenyPolicy(ctx, resourceType)
+  if rejected then return rejected end
+
+  local effectiveRate = resolveEffectiveRate(ctx)
+
+  local senderData, receiverData
+  if resourceType == METAL then
+    senderData = ctx.sender.metal
+    receiverData = ctx.receiver.metal
+  else
+    senderData = ctx.sender.energy
+    receiverData = ctx.receiver.energy
+  end
+
+  local taxedSendable = math.max(0, senderData.current) * (1 - effectiveRate)
+  local capacity = receiverData.storage - receiverData.current
+
+  local result = policyResultPool[resourceType]
+  if not result then
+    result = {}
+    policyResultPool[resourceType] = result
+  end
+
+  Shared.CombineResourcePolicy(taxedSendable, effectiveRate, capacity,
+    ctx.senderTeamId, ctx.receiverTeamId, resourceType, result)
+  result.techBlocking = ctx.ext and ctx.ext.techBlocking or nil
+
+  return result
+end
+
+---@param springRepo SpringSynced
+---@param teamId number
+---@return boolean
+local function teamActive(springRepo, teamId)
+  local n = springRepo.GetTeamRulesParam(teamId, "numActivePlayers")
+  if n == nil then return true end
+  return tonumber(n) ~= 0
+end
+
+---Compute and cache one team's resource factor record for a single resource.
+---@param springRepo SpringSynced
+---@param teamId number
+---@param resourceType ResourceName
+---@param ctx PolicyContext self-context (sender==receiver==teamId) so the enricher resolves the team's tax
+function Gadgets.CacheTeamFactor(springRepo, teamId, resourceType, ctx)
+  local data = (resourceType == METAL) and ctx.sender.metal or ctx.sender.energy
+  local effectiveRate = resolveEffectiveRate(ctx)
+  local isNonPlayer = isNonPlayerTeam(springRepo, teamId)
+  local active = teamActive(springRepo, teamId)
+  local factor = {
+    taxedSendable = math.max(0, data.current) * (1 - effectiveRate),
+    taxRate = effectiveRate,
+    capacity = data.storage - data.current,
+    isNonPlayer = isNonPlayer,
+    active = active,
+  }
+  springRepo.SetTeamRulesParam(teamId, Shared.MakeFactorKey(resourceType), Shared.SerializeResourceFactor(factor))
+  -- Policy fields only; live amounts (taxedSendable/capacity) would fire every economy tick.
+  local signature = string.format("%s|%s|%s", tostring(effectiveRate), tostring(active), tostring(isNonPlayer))
+  PolicyEvents.NotifyIfChanged(teamId, resourceType, signature)
+end
+
+---refresh the per-team resource factor cache (O(teams), factors are independent); pairs reconstructed on read
+---@param springRepo SpringSynced
+---@param frame number
+---@param lastUpdate number
+---@param updateRate number
+---@param contextFactory table
+---@return number lastUpdate New last update frame
+function Gadgets.UpdatePolicyCache(springRepo, frame, lastUpdate, updateRate, contextFactory)
+  if frame < lastUpdate + updateRate then
+    return lastUpdate
+  end
+
+  contextFactory.clearResourceCache()
+
+  local allTeams = springRepo.GetTeamList()
+  for _, teamId in ipairs(allTeams) do
+    local ctx = contextFactory.policy(teamId, teamId)
+    Gadgets.CacheTeamFactor(springRepo, teamId, METAL, ctx)
+    Gadgets.CacheTeamFactor(springRepo, teamId, ENERGY, ctx)
+  end
+
+  return frame
+end
+
+---@param springRepo SpringSynced
+---@param teamsList TeamResourceData[]
+function Gadgets.WaterfillSolve(springRepo, teamsList)
+  return WaterfillSolver.Solve(springRepo, teamsList)
+end
+
+return Gadgets

--- a/common/luaUtilities/team_transfer/transfer_enums.lua
+++ b/common/luaUtilities/team_transfer/transfer_enums.lua
@@ -1,0 +1,46 @@
+local ResourceTypes = VFS.Include("gamedata/resource_types.lua")
+
+local M = {}
+
+M.PolicyType = Spring and Spring.PolicyType or {
+	MetalTransfer = 1,
+	EnergyTransfer = 2,
+	UnitTransfer = 3,
+}
+
+M.TransferCategory = M.PolicyType
+
+M.ResourceType = ResourceTypes
+
+M.ResourceCommunicationCase = {
+	OnSelf = 1,
+	OnTaxFree = 2,
+	OnTaxed = 3,
+	OnDisabled = 4,
+}
+
+M.UnitCommunicationCase = {
+	OnSelf = 1,
+	OnFullyShareable = 2,
+	OnPartiallyShareable = 3,
+	OnPolicyDisabled = 4,
+	OnSelectionValidationFailed = 5,
+	OnTechBlocked = 6,
+}
+
+M.UnitValidationOutcome = {
+	Failure = "Failure",
+	PartialSuccess = "PartialSuccess",
+	Success = "Success",
+}
+
+M.UnitType = {
+	Combat = "combat",
+	Commander = "commander",
+	Constructor = "constructor",
+	Factory = "factory",
+	Resource = "resource",
+	Utility = "utility",
+}
+
+return M

--- a/common/luaUtilities/team_transfer/unit_transfer_shared.lua
+++ b/common/luaUtilities/team_transfer/unit_transfer_shared.lua
@@ -1,0 +1,330 @@
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/team_transfer/transfer_enums.lua")
+local PolicyShared = VFS.Include("common/luaUtilities/team_transfer/team_transfer_serialization_helpers.lua")
+local UnitSharingCategories = VFS.Include("common/luaUtilities/team_transfer/unit_sharing_categories.lua")
+local Comms = VFS.Include("common/luaUtilities/team_transfer/unit_transfer_comms.lua")
+
+local Shared = Comms
+
+local FieldTypes = PolicyShared.FieldTypes
+Shared.UnitPolicyFields = {
+  canShare = FieldTypes.boolean,
+  sharingModes = FieldTypes.string,
+  -- carried to the widget so the share tooltip can surface the share-time effects
+  buildDelaySeconds = FieldTypes.number,
+  stunSeconds = FieldTypes.number,
+  stunCategory = FieldTypes.string,
+}
+
+-- cached per-team factors; GetCachedPolicyResult rebuilds any pair on read (alliance + active stay live)
+Shared.UnitFactorFields = {
+  sharingModes = FieldTypes.string,
+  active = FieldTypes.boolean,
+}
+
+---Rules-param key for a team's unit factor record (owner team = the rules-param team).
+---@return string
+function Shared.MakeFactorKey()
+  return TransferEnums.TransferCategory.UnitTransfer .. "_factor"
+end
+
+---@param factor table {sharingModes: string[], active: boolean}
+---@return string
+function Shared.SerializeUnitFactor(factor)
+  return PolicyShared.Serialize(Shared.UnitFactorFields, {
+    sharingModes = table.concat(factor.sharingModes or { ModeEnums.UnitFilterCategory.None }, ","),
+    active = factor.active,
+  })
+end
+
+---@param serialized string
+---@return table {sharingModes: string[], active: boolean}
+function Shared.DeserializeUnitFactor(serialized)
+  local raw = PolicyShared.Deserialize(Shared.UnitFactorFields, serialized)
+  local modes = {}
+  for m in (raw.sharingModes or "none"):gmatch("[^,]+") do
+    modes[#modes + 1] = m
+  end
+  return { sharingModes = modes, active = raw.active }
+end
+
+---Validate a list of unitIds under current mode
+---@param policyResult UnitPolicyResult -- note that policyResult is useless right now but is passed in for future use
+---@param unitDefID number
+---@param stunCategory string
+---@param defs table
+---@return boolean
+local function wouldBeStunned(unitDefID, stunCategory, defs)
+  if not stunCategory then
+    return false
+  end
+  return Shared.IsShareableDef(unitDefID, stunCategory, defs)
+end
+
+---clear an array in place so a lifted result table can be reused without churning garbage
+---@param arr table
+local function resetArray(arr)
+  for i = #arr, 1, -1 do
+    arr[i] = nil
+  end
+end
+
+---@param unitIds number[]
+---@param springApi SpringSynced?
+---@param unitDefs table?
+---@param out UnitValidationResult? optional pre-allocated result to fill in place (table lifting)
+---@return UnitValidationResult
+function Shared.ValidateUnits(policyResult, unitIds, springApi, unitDefs, out)
+  local spring = springApi or Spring
+  local defs = unitDefs or UnitDefs or (spring.GetUnitDefs and spring.GetUnitDefs()) or {}
+
+  -- reuse caller's table when supplied; scalars reassigned and arrays cleared so stale entries never leak
+  out = out or {}
+  out.status = TransferEnums.UnitValidationOutcome.Failure
+  out.validUnitCount = 0
+  out.invalidUnitCount = 0
+  out.buildDelayedUnitCount = 0 -- valid units that will receive the constructor build delay
+  out.stunnedUnitCount = 0      -- valid units that will be stunned (stun category)
+  out.validUnitNames = out.validUnitNames or {}
+  out.validUnitIds = out.validUnitIds or {}
+  out.invalidUnitNames = out.invalidUnitNames or {}
+  out.invalidUnitIds = out.invalidUnitIds or {}
+  resetArray(out.validUnitNames)
+  resetArray(out.validUnitIds)
+  resetArray(out.invalidUnitNames)
+  resetArray(out.invalidUnitIds)
+
+  if (not policyResult.canShare) or (not unitIds or #unitIds == 0) then
+    return out
+  end
+
+  local modes = policyResult.sharingModes or {"none"}
+  local stunSeconds = tonumber(policyResult.stunSeconds) or 0
+  local stunCategory = policyResult.stunCategory
+
+  -- dedupe sets stay call-local; a shared one would leak keys across rotating `out` tables
+  local validUnitNamesSet = {}
+  local invalidUnitNamesSet = {}
+  for _, unitId in ipairs(unitIds) do
+    local unitDefID = spring.GetUnitDefID(unitId)
+    if not unitDefID then
+      spring.Log("unit_transfer_shared", tostring(LOG.ERROR), string.format("ValidateUnits: unitId %d not found", unitId))
+      out.invalidUnitCount = out.invalidUnitCount + 1
+      table.insert(out.invalidUnitIds, unitId)
+      if not invalidUnitNamesSet["Unknown Unit"] then
+        invalidUnitNamesSet["Unknown Unit"] = true
+        table.insert(out.invalidUnitNames, "Unknown Unit")
+      end
+    else
+      local ok = Shared.IsShareableDef(unitDefID, modes, defs)
+      local def = defs[unitDefID] or defs[tostring(unitDefID)]
+      local unitName = (def and (def.translatedHumanName or def.name)) or tostring(unitDefID)
+      
+      -- Block nanoframes for units that would be stunned (prevents tax bypass)
+      if ok and stunSeconds > 0 and wouldBeStunned(unitDefID, stunCategory, defs) then
+        local beingBuilt, buildProgress = spring.GetUnitIsBeingBuilt(unitId)
+        if beingBuilt and buildProgress > 0 then
+          ok = false
+        end
+      end
+      
+      if ok then
+        out.validUnitCount = out.validUnitCount + 1
+        table.insert(out.validUnitIds, unitId)
+        if UnitSharingCategories.isMobileBuilderDef(def) then
+          out.buildDelayedUnitCount = out.buildDelayedUnitCount + 1
+        end
+        if wouldBeStunned(unitDefID, stunCategory, defs) then
+          out.stunnedUnitCount = out.stunnedUnitCount + 1
+        end
+        if not validUnitNamesSet[unitName] then
+          validUnitNamesSet[unitName] = true
+          table.insert(out.validUnitNames, unitName)
+        end
+      else
+        out.invalidUnitCount = out.invalidUnitCount + 1
+        table.insert(out.invalidUnitIds, unitId)
+        if not invalidUnitNamesSet[unitName] then
+          invalidUnitNamesSet[unitName] = true
+          table.insert(out.invalidUnitNames, unitName)
+        end
+      end
+    end
+  end
+
+  if out.validUnitCount > 0 and out.invalidUnitCount == 0 then
+    out.status = TransferEnums.UnitValidationOutcome.Success
+  elseif out.validUnitCount > 0 and out.invalidUnitCount > 0 then
+    out.status = TransferEnums.UnitValidationOutcome.PartialSuccess
+  else
+    out.status = TransferEnums.UnitValidationOutcome.Failure
+  end
+
+  return out
+end
+
+---rebuild (sender,receiver) unit policy from cached factors + live gates (mirrors Synced.GetPolicy); missing factors fall back to global unit_sharing_mode
+---@param senderTeamId number
+---@param receiverTeamId number
+---@param springApi SpringSynced?
+---@return UnitPolicyResult
+function Shared.GetCachedPolicyResult(senderTeamId, receiverTeamId, springApi)
+  local spring = springApi or Spring
+  local modOptions = spring.GetModOptions()
+  local stunSeconds = tonumber(modOptions[ModeEnums.ModOptions.UnitShareStunSeconds]) or 0
+  local stunCategory = modOptions[ModeEnums.ModOptions.UnitStunCategory] or ModeEnums.UnitFilterCategory.Resource
+  local buildDelaySeconds = tonumber(modOptions[ModeEnums.ModOptions.ConstructorBuildDelay]) or 0
+
+  local areAllied = (spring.AreTeamsAllied and spring.AreTeamsAllied(senderTeamId, receiverTeamId)) == true
+
+  local factorKey = Shared.MakeFactorKey()
+  local senderSerialized = spring.GetTeamRulesParam(senderTeamId, factorKey)
+  local receiverSerialized = spring.GetTeamRulesParam(receiverTeamId, factorKey)
+
+  if senderSerialized == nil or receiverSerialized == nil then
+    -- Pre-cache fallback: global mode + alliance only (matches legacy behaviour).
+    local category = modOptions.unit_sharing_mode or ModeEnums.UnitFilterCategory.None
+    ---@type UnitPolicyResult
+    return {
+      senderTeamId = senderTeamId,
+      receiverTeamId = receiverTeamId,
+      canShare = areAllied and category ~= ModeEnums.UnitFilterCategory.None,
+      sharingModes = { category },
+      stunSeconds = stunSeconds,
+      stunCategory = stunCategory,
+      buildDelaySeconds = buildDelaySeconds,
+    }
+  end
+
+  local senderFactor = Shared.DeserializeUnitFactor(senderSerialized)
+  local receiverFactor = Shared.DeserializeUnitFactor(receiverSerialized)
+  local modes = senderFactor.sharingModes
+  local modeNotNone = not (#modes == 1 and modes[1] == ModeEnums.UnitFilterCategory.None)
+
+  local canShare = areAllied and modeNotNone
+  if canShare and not (spring.IsCheatingEnabled and spring.IsCheatingEnabled()) then
+    if not receiverFactor.active then
+      canShare = false
+    end
+  end
+
+  ---@type UnitPolicyResult
+  return {
+    senderTeamId = senderTeamId,
+    receiverTeamId = receiverTeamId,
+    canShare = canShare,
+    sharingModes = modes,
+    stunSeconds = stunSeconds,
+    stunCategory = stunCategory,
+    buildDelaySeconds = buildDelaySeconds,
+  }
+end
+
+local allUnitTypes = {
+  TransferEnums.UnitType.Combat,
+  TransferEnums.UnitType.Commander,
+  TransferEnums.UnitType.Constructor,
+  TransferEnums.UnitType.Factory,
+  TransferEnums.UnitType.Resource,
+  TransferEnums.UnitType.Utility,
+}
+
+function Shared.GetModeUnitTypes(category)
+  if category == ModeEnums.UnitFilterCategory.None then
+    return {}
+  end
+
+  if category == ModeEnums.UnitFilterCategory.All then
+    return allUnitTypes
+  end
+
+  if category == ModeEnums.UnitFilterCategory.Combat then
+    return {TransferEnums.UnitType.Combat, TransferEnums.UnitType.Commander}
+  end
+
+  if category == ModeEnums.UnitFilterCategory.Buildings then
+    return {TransferEnums.UnitType.Factory, TransferEnums.UnitType.Resource, TransferEnums.UnitType.Utility}
+  end
+
+  if category == ModeEnums.UnitFilterCategory.Constructors then
+    return {TransferEnums.UnitType.Constructor}
+  end
+
+  if category == ModeEnums.UnitFilterCategory.Resource then
+    return {TransferEnums.UnitType.Resource}
+  end
+
+  if category == ModeEnums.UnitFilterCategory.NonCombat then
+    return {
+      TransferEnums.UnitType.Constructor,
+      TransferEnums.UnitType.Factory,
+      TransferEnums.UnitType.Resource,
+      TransferEnums.UnitType.Utility,
+    }
+  end
+
+  return {}
+end
+
+local function UnitTypeMatchesCategory(unitDef, category)
+  local unitType = UnitSharingCategories.classifyUnitDef(unitDef)
+  local categoryUnitTypes = Shared.GetModeUnitTypes(category)
+  return table.contains(categoryUnitTypes, unitType)
+end
+
+---@param unitDef table
+---@param category string
+---@return boolean
+local function EvaluateUnitForSharing(unitDef, category)
+  if not unitDef then return false end
+
+  if category == ModeEnums.UnitFilterCategory.None then
+    return false
+  end
+
+  if category == ModeEnums.UnitFilterCategory.All then
+    return true
+  end
+
+  return UnitTypeMatchesCategory(unitDef, category)
+end
+
+local allowedByCategory = setmetatable({}, { __mode = "k" })
+
+local function BuildAllowedCacheForCategory(category, unitDefs)
+  local defs = unitDefs or UnitDefs
+  if not defs then return nil end
+  local cacheByDefs = allowedByCategory[defs]
+  if not cacheByDefs then
+    cacheByDefs = {}
+    allowedByCategory[defs] = cacheByDefs
+  end
+  if cacheByDefs[category] then
+    return cacheByDefs[category]
+  end
+  local cache = {}
+  for unitDefID, unitDef in pairs(defs) do
+    if EvaluateUnitForSharing(unitDef, category) then
+      cache[unitDefID] = true
+    end
+  end
+  cacheByDefs[category] = cache
+  return cache
+end
+
+---@param unitDefId number
+---@param categories string|string[]
+---@param unitDefs table?
+---@return boolean
+function Shared.IsShareableDef(unitDefId, categories, unitDefs)
+  if not unitDefId or not categories then return false end
+  if type(categories) == "string" then categories = {categories} end
+  for _, category in ipairs(categories) do
+    if category == ModeEnums.UnitFilterCategory.All then return true end
+    local cache = BuildAllowedCacheForCategory(category, unitDefs)
+    if cache and cache[unitDefId] then return true end
+  end
+  return false
+end
+
+return Shared

--- a/common/luaUtilities/team_transfer/unit_transfer_synced.lua
+++ b/common/luaUtilities/team_transfer/unit_transfer_synced.lua
@@ -1,0 +1,97 @@
+local ModeEnums = VFS.Include("modes/sharing_mode_enums.lua")
+local TransferEnums = VFS.Include("common/luaUtilities/team_transfer/transfer_enums.lua")
+local Shared = VFS.Include("common/luaUtilities/team_transfer/unit_transfer_shared.lua")
+local PolicyEvents = VFS.Include("common/luaUtilities/team_transfer/policy_events.lua")
+
+local Synced = {
+  ValidateUnits = Shared.ValidateUnits,
+  GetModeUnitTypes = Shared.GetModeUnitTypes,
+}
+
+---Build per-pair policy (expose) from context
+---@param ctx PolicyContext
+---@return UnitPolicyResult
+function Synced.GetPolicy(ctx)
+  local modOptions = ctx.springRepo.GetModOptions()
+  local modes = ctx.unitSharingModes or { modOptions.unit_sharing_mode or ModeEnums.UnitFilterCategory.None }
+  local canShare = ctx.areAlliedTeams and not (#modes == 1 and modes[1] == ModeEnums.UnitFilterCategory.None)
+  if canShare and not ctx.isCheatingEnabled then
+    local numActivePlayers = ctx.springRepo.GetTeamRulesParam(ctx.receiverTeamId, "numActivePlayers")
+    if numActivePlayers ~= nil and tonumber(numActivePlayers) == 0 then
+      canShare = false
+    end
+  end
+  local stunSeconds = tonumber(modOptions[ModeEnums.ModOptions.UnitShareStunSeconds]) or 0
+  local stunCategory = modOptions[ModeEnums.ModOptions.UnitStunCategory] or ModeEnums.UnitFilterCategory.Resource
+  local buildDelaySeconds = tonumber(modOptions[ModeEnums.ModOptions.ConstructorBuildDelay]) or 0
+  return {
+    canShare = canShare,
+    senderTeamId = ctx.senderTeamId,
+    receiverTeamId = ctx.receiverTeamId,
+    sharingModes = modes,
+    stunSeconds = stunSeconds,
+    stunCategory = stunCategory,
+    buildDelaySeconds = buildDelaySeconds,
+    techBlocking = ctx.ext and ctx.ext.techBlocking or nil,
+  }
+end
+
+---Execute unit transfer with pre-validated units
+---@param ctx UnitTransferContext
+---@return UnitTransferResult
+function Synced.UnitTransfer(ctx)
+  local policyResult = ctx.policyResult
+
+  if not policyResult.canShare then
+    ---@type UnitTransferResult
+    return {
+      success = false,
+      outcome = TransferEnums.UnitValidationOutcome.Failure,
+      senderTeamId = ctx.senderTeamId,
+      receiverTeamId = ctx.receiverTeamId,
+      validationResult = ctx.validationResult,
+      policyResult = ctx.policyResult
+    }
+  end
+
+  for _, unitId in ipairs(ctx.validationResult.validUnitIds) do
+    -- ctx.given should always be false here because we short-circuit inside AllowResourceTransfer
+    ctx.springRepo.TransferUnit(unitId, ctx.receiverTeamId, ctx.given)
+  end
+
+  ---@type UnitTransferResult
+  return {
+    success = true,
+    outcome = ctx.validationResult.status,
+    senderTeamId = ctx.senderTeamId,
+    receiverTeamId = ctx.receiverTeamId,
+    validationResult = ctx.validationResult,
+    policyResult = ctx.policyResult
+  }
+end
+
+---@param springRepo SpringSynced
+---@param teamId number
+---@return boolean
+local function teamActive(springRepo, teamId)
+  local n = springRepo.GetTeamRulesParam(teamId, "numActivePlayers")
+  if n == nil then return true end
+  return tonumber(n) ~= 0
+end
+
+---Compute and cache one team's unit factor: its tech-resolved sharing modes + active flag.
+---@param springRepo SpringSynced
+---@param teamId number
+---@param ctx PolicyContext self-context (sender==receiver==teamId) so the enricher resolves the team's modes
+function Synced.CacheTeamFactor(springRepo, teamId, ctx)
+  local modes = ctx.unitSharingModes or
+    { springRepo.GetModOptions().unit_sharing_mode or ModeEnums.UnitFilterCategory.None }
+  local serialized = Shared.SerializeUnitFactor({
+    sharingModes = modes,
+    active = teamActive(springRepo, teamId),
+  })
+  springRepo.SetTeamRulesParam(teamId, Shared.MakeFactorKey(), serialized)
+  PolicyEvents.NotifyIfChanged(teamId, PolicyEvents.Domain.Unit, serialized)
+end
+
+return Synced

--- a/luarules/gadgets/game_frametime_broadcast.lua
+++ b/luarules/gadgets/game_frametime_broadcast.lua
@@ -1,0 +1,51 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name    = "Frame Time Broadcast",
+		desc    = "Broadcasts per-client sim and draw frame times into the demo packet stream",
+		author  = "bruno-dasilva",
+		date    = "2026-04",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true,
+	}
+end
+
+if gadgetHandler:IsSyncedCode() then return end
+
+local sendPacketEverySeconds = 2
+
+local GetLastUpdateSeconds  = Spring.GetLastUpdateSeconds
+local GetProfilerTimeRecord = Spring.GetProfilerTimeRecord
+local SendLuaRulesMsg       = Spring.SendLuaRulesMsg
+
+local updateTimer = 0
+local simN,  simSum,  simPeak  = 0, 0, 0
+local drawN, drawSum, drawPeak = 0, 0, 0
+
+function gadget:GameFrame(_)
+	local _, simCurrent = GetProfilerTimeRecord("Sim", false)
+	simN   = simN + 1
+	simSum = simSum + simCurrent
+	if simCurrent > simPeak then simPeak = simCurrent end
+end
+
+function gadget:Update()
+	updateTimer = updateTimer + GetLastUpdateSeconds()
+
+	local _, drawCurrent = GetProfilerTimeRecord("Draw", false)
+	drawN   = drawN + 1
+	drawSum = drawSum + drawCurrent
+	if drawCurrent > drawPeak then drawPeak = drawCurrent end
+
+	if updateTimer > sendPacketEverySeconds then
+		local avgSim  = simN  > 0 and (simSum  / simN)  or 0
+		local avgDraw = drawN > 0 and (drawSum / drawN) or 0
+		SendLuaRulesMsg(string.format("#ft%d/%d/%.1f/%.1f/%.1f/%.1f",
+			simN, drawN, avgSim, simPeak, avgDraw, drawPeak))
+		updateTimer = 0
+		simN,  simSum,  simPeak  = 0, 0, 0
+		drawN, drawSum, drawPeak = 0, 0, 0
+	end
+end

--- a/luarules/gadgets/game_frametime_broadcast.lua
+++ b/luarules/gadgets/game_frametime_broadcast.lua
@@ -24,20 +24,32 @@ local updateTimer = 0
 local simN,  simSum,  simPeak  = 0, 0, 0
 local drawN, drawSum, drawPeak = 0, 0, 0
 
+-- `total` (1st return) is a monotonic accumulator of time spent in the zone,
+-- the per-frame cost is the delta between two reads.
+local prevSimTotal, prevDrawTotal
+
 function gadget:GameFrame(_)
-	local _, simCurrent = GetProfilerTimeRecord("Sim", false)
-	simN   = simN + 1
-	simSum = simSum + simCurrent
-	if simCurrent > simPeak then simPeak = simCurrent end
+    local simTotal = GetProfilerTimeRecord("Sim", false)
+	if prevSimTotal then
+			local simFrame = simTotal - prevSimTotal
+			simN   = simN + 1
+			simSum = simSum + simFrame
+			if simFrame > simPeak then simPeak = simFrame end
+	end
+	prevSimTotal = simTotal
 end
 
 function gadget:Update()
 	updateTimer = updateTimer + GetLastUpdateSeconds()
 
-	local _, drawCurrent = GetProfilerTimeRecord("Draw", false)
-	drawN   = drawN + 1
-	drawSum = drawSum + drawCurrent
-	if drawCurrent > drawPeak then drawPeak = drawCurrent end
+	local drawTotal = GetProfilerTimeRecord("Draw", false)
+	if prevDrawTotal then
+		local drawFrame = drawTotal - prevDrawTotal
+		drawN   = drawN + 1
+		drawSum = drawSum + drawFrame
+		if drawFrame > drawPeak then drawPeak = drawFrame end
+	end
+	prevDrawTotal = drawTotal
 
 	if updateTimer > sendPacketEverySeconds then
 		local avgSim  = simN  > 0 and (simSum  / simN)  or 0

--- a/luarules/gadgets/game_initial_spawn.lua
+++ b/luarules/gadgets/game_initial_spawn.lua
@@ -722,8 +722,9 @@ if gadgetHandler:IsSyncedCode() then
                     if GG.SpawnEnvironmentalLightning then
                         GG.SpawnEnvironmentalLightning("commanderspawn", x, y, z)
                     end
-					GG.ComSpawnDefoliate(x, y, z)
-
+                    if GG.ComSpawnDefoliate then
+						GG.ComSpawnDefoliate(x, y, z)
+					end
                 end
             end
             if n == spawnWarpInFrame then

--- a/luarules/gadgets/gfx_tree_feller.lua
+++ b/luarules/gadgets/gfx_tree_feller.lua
@@ -104,17 +104,21 @@ if gadgetHandler:IsSyncedCode() then
 
 	local GetFeaturePosition = Spring.GetFeaturePosition
 	local GetFeatureHealth = Spring.GetFeatureHealth
+	local GetFeatureDefID = Spring.GetFeatureDefID
 	local GetFeatureDirection = Spring.GetFeatureDirection
 	local GetFeatureResources = Spring.GetFeatureResources
+	local GetAllFeatures = Spring.GetAllFeatures
 	local SetFeatureDirection = Spring.SetFeatureDirection
 	local SetFeatureBlocking = Spring.SetFeatureBlocking
 	local SetFeaturePosition = Spring.SetFeaturePosition
 	local SetFeatureHealth = Spring.SetFeatureHealth
+	local SetFeatureMaxHealth = Spring.SetFeatureMaxHealth
 	local CreateFeature = Spring.CreateFeature
 	local DestroyFeature = Spring.DestroyFeature
 	local GetGameFrame = Spring.GetGameFrame
 
 	local treesdying = {}
+	local postStartNormalized = false
 	local falltime = 55.0 -- in frames
 	-- Visual topple duration (frames). Kept independent of `strength` so that
 	-- fire-killed trees (which take tiny damage and thus have a huge strength /
@@ -212,7 +216,39 @@ if gadgetHandler:IsSyncedCode() then
 		return height, radius, canopyFrac
 	end
 
+	local IsLikelyTreeFeature
+	local function NormalizeZeroHealthTrees()
+		local allFeatures = GetAllFeatures()
+		local fixedCount = 0
+		for i = 1, #allFeatures do
+			local featureID = allFeatures[i]
+			local featureDefID = GetFeatureDefID(featureID)
+			if featureDefID and not geothermals[featureDefID] then
+				local _, maxMetal, _, maxEnergy = GetFeatureResources(featureID)
+				if maxMetal == 0 and maxEnergy > 0 then
+					local health, maxHealth = GetFeatureHealth(featureID)
+					if health and maxHealth and maxHealth > 0 and health <= 0 then
+						-- Some maps place trees with health=0. Tree shader reads healthFraction
+						-- directly for charring, so those trees render fully burnt at game start.
+						-- Normalize only pathological zero-health trees back to max health.
+						-- This does NOT replace the feature, it only updates health values.
+						SetFeatureMaxHealth(featureID, maxHealth)
+						SetFeatureHealth(featureID, maxHealth, false)
+						fixedCount = fixedCount + 1
+					end
+				end
+			end
+		end
+		return fixedCount
+	end
 
+	IsLikelyTreeFeature = function(featureID, featureDefID)
+		if geothermals[featureDefID] then
+			return false
+		end
+		local _, maxMetal, _, maxEnergy = GetFeatureResources(featureID)
+		return maxMetal == 0 and maxEnergy > 0
+	end
 
 	local function ComSpawnDefoliate(spawnx,spawny,spawnz)
 
@@ -356,6 +392,27 @@ if gadgetHandler:IsSyncedCode() then
 	function gadget:Initialize()
 		-- At game start, just remove trees already submerged by lava (no fire animation)
 		checkLavaTreesDestroy()
+		NormalizeZeroHealthTrees()
+		if TREEFELLER_DEBUG then
+			dbg("startup normalization completed")
+		end
+	end
+
+	function gadget:GameStart()
+		local fixedCount = NormalizeZeroHealthTrees()
+		postStartNormalized = true
+	end
+
+	function gadget:FeatureCreated(featureID, allyTeam, sourceID)
+		local featureDefID = GetFeatureDefID(featureID)
+		if not featureDefID or not IsLikelyTreeFeature(featureID, featureDefID) then
+			return
+		end
+		local health, maxHealth = GetFeatureHealth(featureID)
+		if health and maxHealth and maxHealth > 0 and health <= 0 then
+			SetFeatureMaxHealth(featureID, maxHealth)
+			SetFeatureHealth(featureID, maxHealth, false)
+		end
 	end
 
 
@@ -502,6 +559,11 @@ if gadgetHandler:IsSyncedCode() then
 	end
 
 	function gadget:GameFrame(gf)
+		if not postStartNormalized and gf >= 1 then
+			NormalizeZeroHealthTrees()
+			postStartNormalized = true
+		end
+
 		-- Periodically check for lava rise and ignite newly submerged trees
 		if gf % lavaCheckInterval == 0 then
 			checkLavaTreesFire(gf)

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -172,7 +172,7 @@ if gadgetHandler:IsSyncedCode() then
 	local bosses = {resistances = queenResistance, statuses = {}, playerDamages = {}}
 	local raptorTeamID = Spring.Utilities.GetRaptorTeamID()
 	local raptorAllyTeamID = Spring.Utilities.GetRaptorAllyTeamID()
-	local lsx1, lsz1, lsx2, lsz2
+	local lsx1, lsz1, lsx2, lsz2 = 0, 0, Game.mapSizeX, Game.mapSizeZ
 	local burrows = {}
 	local aliveEggsTable = {}
 	local squadsTable = {}

--- a/luarules/gadgets/raptor_spawner_defense.lua
+++ b/luarules/gadgets/raptor_spawner_defense.lua
@@ -956,6 +956,18 @@ if gadgetHandler:IsSyncedCode() then
 				else
 					queenStagger.currentlyStaggered = true
 					queenStagger.CurrentTimer = queenStagger.Time + 0
+					for queenID, _ in pairs(queenIDs) do
+						local ux, uy, uz = Spring.GetUnitPosition(queenID)
+						Spring.AddUnitDamage(queenID, 0, 1600000)
+						Spring.SetUnitHealth(queenID, {paralyze = 16000000})
+						for j = 1,50 do
+							if GG.SpawnEnvironmentalLightning then
+								GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-1000, 1000), uy+100, uz+math.random(-1000, 1000))
+							else
+								SpawnCEG("scavradiation-lightning", ux+math.random(-1000, 1000), uy+100, uz+math.random(-1000, 1000), 0,0,0)
+							end
+						end
+					end
 					SetGameRulesParam("raptorQueenStaggerPercentage", math.ceil((1 - (queenStagger.CurrentTimer/queenStagger.Time))*100))
 				end
 			end
@@ -965,7 +977,16 @@ if gadgetHandler:IsSyncedCode() then
 				if queenStagger.CurrentTimer > 0 then
 					SetGameRulesParam("raptorQueenStaggerPercentage", math.ceil((1 - (queenStagger.CurrentTimer/queenStagger.Time))*100))
 					for queenID, _ in pairs(queenIDs) do
+						local ux, uy, uz = Spring.GetUnitPosition(queenID)
+						Spring.AddUnitDamage(queenID, 0, 1600000)
 						Spring.SetUnitHealth(queenID, {paralyze = 16000000})
+						for j = 1,10 do
+							if GG.SpawnEnvironmentalLightning then
+								GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500))
+							else
+								SpawnCEG("scavradiation-lightning", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500), 0,0,0)
+							end
+						end
 					end
 				else
 					queenStagger.currentlyStaggered = false
@@ -1552,6 +1573,12 @@ if gadgetHandler:IsSyncedCode() then
 				if queenStagger.currentlyStaggered then
 					damage = damage - (damage * resistPercent * 0.5)
 					queenStagger.CurrentTimer = queenStagger.CurrentTimer - (damage*0.0001)
+					local ux, uy, uz = Spring.GetUnitPosition(unitID)
+					if GG.SpawnEnvironmentalLightning then
+						GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500))
+					else
+						SpawnCEG("scavradiation-lightning", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500), 0,0,0)
+					end
 				else
 					damage = damage - (damage * resistPercent)
 				end

--- a/luarules/gadgets/scav_spawner_defense.lua
+++ b/luarules/gadgets/scav_spawner_defense.lua
@@ -1105,6 +1105,18 @@ if gadgetHandler:IsSyncedCode() then
 				else
 					bossStagger.currentlyStaggered = true
 					bossStagger.CurrentTimer = bossStagger.Time + 0
+					for bossID, _ in pairs(bossIDs) do
+						local ux, uy, uz = Spring.GetUnitPosition(bossID)
+						Spring.AddUnitDamage(bossID, 0, 1600000)
+						Spring.SetUnitHealth(bossID, {paralyze = 16000000})
+						for j = 1,50 do
+							if GG.SpawnEnvironmentalLightning then
+								GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-1000, 1000), uy+100, uz+math.random(-1000, 1000))
+							else
+								SpawnCEG("scavradiation-lightning", ux+math.random(-1000, 1000), uy+100, uz+math.random(-1000, 1000), 0,0,0)
+							end
+						end
+					end
 					SetGameRulesParam("scavBossStaggerPercentage", math.ceil((1 - (bossStagger.CurrentTimer/bossStagger.Time))*100))
 				end
 			end
@@ -1114,7 +1126,16 @@ if gadgetHandler:IsSyncedCode() then
 				if bossStagger.CurrentTimer > 0 then
 					SetGameRulesParam("scavBossStaggerPercentage", math.ceil((1 - (bossStagger.CurrentTimer/bossStagger.Time))*100))
 					for bossID, _ in pairs(bossIDs) do
+						local ux, uy, uz = Spring.GetUnitPosition(bossID)
+						Spring.AddUnitDamage(bossID, 0, 1600000)
 						Spring.SetUnitHealth(bossID, {paralyze = 16000000})
+						for j = 1,10 do
+							if GG.SpawnEnvironmentalLightning then
+								GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500))
+							else
+								SpawnCEG("scavradiation-lightning", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500), 0,0,0)
+							end
+						end
 					end
 				else
 					bossStagger.currentlyStaggered = false
@@ -1764,6 +1785,12 @@ if gadgetHandler:IsSyncedCode() then
 				if bossStagger.currentlyStaggered then
 					damage = damage - (damage * resistPercent * 0.5)
 					bossStagger.CurrentTimer = bossStagger.CurrentTimer - (damage*0.0001)
+					local ux, uy, uz = Spring.GetUnitPosition(unitID)
+					if GG.SpawnEnvironmentalLightning then
+						GG.SpawnEnvironmentalLightning("scavradiation", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500))
+					else
+						SpawnCEG("scavradiation-lightning", ux+math.random(-500, 500), uy+100, uz+math.random(-500, 500), 0,0,0)
+					end
 				else
 					damage = damage - (damage * resistPercent)
 				end

--- a/luarules/gadgets/unit_area_timed_damage.lua
+++ b/luarules/gadgets/unit_area_timed_damage.lua
@@ -287,7 +287,16 @@ local function addToExplosions(explosions, area)
 	tableInsert(explosions, index, area)
 end
 
-local getBlockingShieldUnits -- from shield behaviors
+local function getBlockingShieldUnits()
+	return nil, 0
+end
+
+local function initBlockingShieldUnits()
+	local shields = GG.Shields
+	if shields and shields.GetBlockingShieldUnits then
+		getBlockingShieldUnits = shields.GetBlockingShieldUnits
+	end
+end
 
 local function getAllyTeam(attackerID, projectileID)
 	return (attackerID and spGetUnitAllyTeam(attackerID))
@@ -324,6 +333,7 @@ local function addTimedExplosion(weaponDefID, px, py, pz, attackerID, projectile
 		-- and the explosion volume and resulting area volume have some discrepancy, as well.
 		local blockingShields
 		if not explosion.penetrates then
+			initBlockingShieldUnits()
 			local allyTeam = getAllyTeam(attackerID, projectileID)
 			local units, count = getBlockingShieldUnits(px, elevation, pz, areaRange, allyTeam, true)
 			if count and count > 0 then
@@ -537,7 +547,7 @@ end
 -- Gadget callins --------------------------------------------------------------
 
 function gadget:Initialize()
-	getBlockingShieldUnits = GG.Shields.GetBlockingShieldUnits
+	initBlockingShieldUnits()
 
 	areaDamageTypes = GG.EnvAreaWeapons or {}
 	inExplosion = GG.InTimedDamageArea or table.new(1, 0) -- lua trick for ref passing

--- a/luarules/gadgets/unit_hats.lua
+++ b/luarules/gadgets/unit_hats.lua
@@ -57,7 +57,13 @@ local spGetTeamUnits = Spring.GetTeamUnits
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetUnitPosition = Spring.GetUnitPosition
 local spCreateUnit = Spring.CreateUnit
-local spGetUnitScriptEnv = Spring.UnitScript.GetScriptEnv
+local function spGetUnitScriptEnv(unitID)
+	local unitScript = Spring.UnitScript
+	if unitScript and unitScript.GetScriptEnv then
+		return unitScript.GetScriptEnv(unitID)
+	end
+	return nil
+end
 local spCallAsUnit = Spring.UnitScript.CallAsUnit
 local spGetCOBScriptID = Spring.GetCOBScriptID
 local spCallCOBScript = Spring.CallCOBScript

--- a/luaui/Widgets/api_playernames.lua
+++ b/luaui/Widgets/api_playernames.lua
@@ -15,6 +15,10 @@ end
 
 -- Localized functions for performance
 local tableInsert = table.insert
+local tableSort = table.sort
+local stringFormat = string.format
+local stringGmatch = string.gmatch
+local tableConcat = table.concat
 
 -- Localized Spring API for performance
 local spEcho = Spring.Echo
@@ -32,6 +36,142 @@ local currentAccounts = {}	-- accountID to name
 local reconnected = false	-- flag to track if this is a reconnection/reload
 
 local spGetPlayerInfo = Spring.GetPlayerInfo
+
+local packedHistoryFormatVersion = 2
+
+local function escapeField(str)
+	return (tostring(str):gsub("%%", "%%25"):gsub("|", "%%7C"):gsub(";", "%%3B"):gsub(",", "%%2C"):gsub("\n", "%%0A"))
+end
+
+local function unescapeField(str)
+	if not str or str == "" then
+		return ""
+	end
+	return (str:gsub("%%(%x%x)", function(hex)
+		return string.char(tonumber(hex, 16))
+	end))
+end
+
+local function splitByDelimiter(str, delimiter)
+	if not str or str == "" then
+		return {}
+	end
+	local out = {}
+	local pattern = stringFormat("([^%s]+)", delimiter)
+	for token in stringGmatch(str, pattern) do
+		out[#out + 1] = token
+	end
+	return out
+end
+
+local function packNameMap(nameMap)
+	if not nameMap then
+		return nil
+	end
+	local records = {}
+	for id, name in pairs(nameMap) do
+		if type(id) == "number" and type(name) == "string" then
+			records[#records + 1] = stringFormat("%d|%s", id, escapeField(name))
+		end
+	end
+	if #records == 0 then
+		return nil
+	end
+	tableSort(records)
+	return tableConcat(records, ";")
+end
+
+local function unpackNameMap(packed)
+	if type(packed) ~= "string" or packed == "" then
+		return nil
+	end
+	local nameMap = {}
+	for _, record in ipairs(splitByDelimiter(packed, ";")) do
+		local fields = splitByDelimiter(record, "|")
+		if #fields == 2 then
+			local id = tonumber(fields[1])
+			if id then
+				nameMap[id] = unescapeField(fields[2])
+			end
+		end
+	end
+	return nameMap
+end
+
+local function packHistory(historyTable)
+	if not historyTable then
+		return nil
+	end
+
+	local records = {}
+	for accountID, data in pairs(historyTable) do
+		if type(accountID) == "number" and type(data) == "table" then
+			local names = {}
+			for k, v in pairs(data) do
+				if type(k) == "number" and type(v) == "string" then
+					names[#names + 1] = { idx = k, name = v }
+				end
+			end
+			tableSort(names, function(a, b) return a.idx < b.idx end)
+
+			local nameParts = {}
+			for i = 1, #names do
+				nameParts[i] = escapeField(names[i].name)
+			end
+
+			records[#records + 1] = stringFormat(
+				"%d|%d|%d|%s|%s",
+				accountID,
+				tonumber(data.i) or 1,
+				tonumber(data.d) or 0,
+				escapeField(data.alias or ""),
+				tableConcat(nameParts, ",")
+			)
+		end
+	end
+
+	if #records == 0 then
+		return nil
+	end
+	tableSort(records)
+	return tableConcat(records, ";")
+end
+
+local function unpackHistory(packed)
+	if type(packed) ~= "string" or packed == "" then
+		return nil
+	end
+
+	local historyTable = {}
+	for _, record in ipairs(splitByDelimiter(packed, ";")) do
+		local fields = splitByDelimiter(record, "|")
+		if #fields == 5 then
+			local accountID = tonumber(fields[1])
+			if accountID then
+				local entry = {
+					i = tonumber(fields[2]) or 1,
+					d = tonumber(fields[3]) or 0,
+				}
+				local alias = unescapeField(fields[4])
+				if alias ~= "" then
+					entry.alias = alias
+				end
+
+				local packedNames = fields[5]
+				if packedNames ~= "" then
+					local idx = 1
+					for _, packedName in ipairs(splitByDelimiter(packedNames, ",")) do
+						entry[idx] = unescapeField(packedName)
+						idx = idx + 1
+					end
+				end
+
+				historyTable[accountID] = entry
+			end
+		end
+	end
+	return historyTable
+end
 
 local function getPlayername(playerID, accountID, skipAlias)
 	if playerID then
@@ -56,7 +196,7 @@ local function getPlayername(playerID, accountID, skipAlias)
 	if name ~= 'unknown' then
 		if accountID then
 			-- find if name exists inhistory
-			local inHistory = falses
+			local inHistory = false
 			if history[accountID] then
 				for i, historyName in pairs(history[accountID]) do	-- using pairs only in case people carelessly delete names from widgetconfig (BYAR.lua)
 					if historyName == name then
@@ -254,17 +394,18 @@ function widget:GetConfigData()
 	return {
 		gameID = Game.gameID and Game.gameID or Spring.GetGameRulesParam("GameID"),
 		applyFirstEncounteredName = applyFirstEncounteredName,
-		history = history,
-		currentNames = currentNames,
-		currentAccounts = currentAccounts,
+		historyPacked = packHistory(history),
+		historyPackedFormat = packedHistoryFormatVersion,
+		currentNamesPacked = packNameMap(currentNames),
+		currentAccountsPacked = packNameMap(currentAccounts),
 	}
 end
 
 function widget:SetConfigData(data)
-	history = data.history or {}
+	history = unpackHistory(data.historyPacked) or data.history or {}
 	if data.gameID and data.gameID == (Game.gameID and Game.gameID or Spring.GetGameRulesParam("GameID")) then
-		currentNames = data.currentNames or {}
-		currentAccounts = data.currentAccounts or {}
+		currentNames = unpackNameMap(data.currentNamesPacked) or data.currentNames or {}
+		currentAccounts = unpackNameMap(data.currentAccountsPacked) or data.currentAccounts or {}
 		reconnected = true
 	end
 	if data.applyFirstEncounteredName ~= nil then

--- a/luaui/Widgets/api_playernames.lua
+++ b/luaui/Widgets/api_playernames.lua
@@ -144,20 +144,20 @@ local function unpackHistory(packed)
 
 	local historyTable = {}
 	for _, record in ipairs(splitByDelimiter(packed, ";")) do
-		local fields = splitByDelimiter(record, "|")
-		if #fields == 5 then
-			local accountID = tonumber(fields[1])
+		-- Parse fixed 5-field record while preserving empty alias field.
+		local accountIDStr, gamesStr, dateStr, aliasStr, packedNames = string.match(record, "^([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$")
+		if accountIDStr then
+			local accountID = tonumber(accountIDStr)
 			if accountID then
 				local entry = {
-					i = tonumber(fields[2]) or 1,
-					d = tonumber(fields[3]) or 0,
+					i = tonumber(gamesStr) or 1,
+					d = tonumber(dateStr) or 0,
 				}
-				local alias = unescapeField(fields[4])
+				local alias = unescapeField(aliasStr)
 				if alias ~= "" then
 					entry.alias = alias
 				end
 
-				local packedNames = fields[5]
 				if packedNames ~= "" then
 					local idx = 1
 					for _, packedName in ipairs(splitByDelimiter(packedNames, ",")) do

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -1915,6 +1915,7 @@ local function UnitScriptDecal(unitID, unitDefID, whichDecal, posx, posz, headin
 end
 
 local pendingRestore = nil  -- Holds saved decal data between SetConfigData and Initialize
+local gameOver = false
 
 function widget:Initialize()
 	--if makeAtlases() == false then
@@ -2094,7 +2095,17 @@ function widget:ShutDown()
 	widgetHandler:DeregisterGlobal('UnitScriptDecal')
 end
 
+function widget:GameOver()
+	gameOver = true
+end
+
 function widget:GetConfigData(_) -- Called by RemoveWidget
+	if gameOver then
+		return {
+			lifeTimeMult = lifeTimeMult,
+		}
+	end
+
 	-- Save the biggest active decals for restoration after luaui reload (cap at 1500)
 	-- Priority: biggest scars first, then biggest footprints if room remains
 	local maxSave = 1500

--- a/luaui/Widgets/gfx_decals_gl4.lua
+++ b/luaui/Widgets/gfx_decals_gl4.lua
@@ -19,6 +19,9 @@ local mathFloor = math.floor
 local mathMin = math.min
 local mathRandom = math.random
 local round = math.round
+local stringFormat = string.format
+local stringGmatch = string.gmatch
+local tableConcat = table.concat
 
 -- Localized Spring API for performance
 local spGetGameFrame = Spring.GetGameFrame
@@ -1917,6 +1920,60 @@ end
 local pendingRestore = nil  -- Holds saved decal data between SetConfigData and Initialize
 local gameOver = false
 
+local savedDecalsFormatVersion = 2
+local savedDecalFieldCount = 13
+
+local function PackSavedDecals(savedDecals)
+	if not savedDecals or #savedDecals == 0 then
+		return nil
+	end
+
+	local packed = {}
+	for i = 1, #savedDecals do
+		local entry = savedDecals[i]
+		if entry and #entry == savedDecalFieldCount then
+			packed[#packed + 1] = stringFormat(
+				"%d,%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.6g,%d,%d,%d",
+				entry[1], entry[2], entry[3], entry[4],
+				entry[5], entry[6], entry[7], entry[8],
+				entry[9], entry[10], entry[11], entry[12], entry[13]
+			)
+		end
+	end
+
+	if #packed == 0 then
+		return nil
+	end
+
+	return tableConcat(packed, ";")
+end
+
+local function UnpackSavedDecals(packed)
+	if type(packed) ~= "string" or packed == "" then
+		return nil
+	end
+
+	local unpacked = {}
+	for packedEntry in stringGmatch(packed, "([^;]+)") do
+		local entry = {}
+		local count = 0
+		local valid = true
+		for field in stringGmatch(packedEntry, "([^,]+)") do
+			count = count + 1
+			entry[count] = tonumber(field)
+			if entry[count] == nil then
+				valid = false
+				break
+			end
+		end
+		if valid and count == savedDecalFieldCount then
+			unpacked[#unpacked + 1] = entry
+		end
+	end
+
+	return unpacked
+end
+
 function widget:Initialize()
 	--if makeAtlases() == false then
 	--	goodbye("Failed to init texture atlas for DecalsGL4")
@@ -2177,7 +2234,8 @@ function widget:GetConfigData(_) -- Called by RemoveWidget
 
 	local savedTable = {
 		lifeTimeMult = lifeTimeMult,
-		savedDecals = savedDecals,
+		savedDecalsPacked = PackSavedDecals(savedDecals),
+		savedDecalsFormat = savedDecalsFormatVersion,
 		saveFrame = frame,
 	}
 	return savedTable
@@ -2187,9 +2245,19 @@ function widget:SetConfigData(data) -- Called on load (and config change), just 
 	if data.lifeTimeMult ~= nil then
 		lifeTimeMult = data.lifeTimeMult
 	end
-	if data.savedDecals and #data.savedDecals > 0 then
+
+	local savedDecals = nil
+	if data.savedDecalsPacked then
+		savedDecals = UnpackSavedDecals(data.savedDecalsPacked)
+	end
+	if (not savedDecals or #savedDecals == 0) and data.savedDecals and #data.savedDecals > 0 then
+		-- Backward compatibility with older plain-table saves.
+		savedDecals = data.savedDecals
+	end
+
+	if savedDecals and #savedDecals > 0 then
 		pendingRestore = {
-			decals = data.savedDecals,
+			decals = savedDecals,
 			saveFrame = data.saveFrame or 0,
 		}
 	end

--- a/luaui/Widgets/gfx_deferred_rendering_GL4.lua
+++ b/luaui/Widgets/gfx_deferred_rendering_GL4.lua
@@ -1558,9 +1558,11 @@ function widget:Update(dt)
 			cursorLights = {}
 		end
 		local cursors, notIdle = WG['allycursors'].getCursors()
+		local isCursorVisible = WG['allycursors'].isCursorVisible
 		for playerID, cursor in pairs(cursors) do
 			local teamColor = teamColors[playerID]
-			if teamColor and not cursor[8] and notIdle[playerID] then
+			local visibleToViewer = (not isCursorVisible) or isCursorVisible(playerID)
+			if teamColor and not cursor[8] and notIdle[playerID] and visibleToViewer then
 				if not cursorLights[playerID] and not cursor[8] then
 					local params = cursorLightParams.lightParamTable	-- see lightParamKeyOrder for which key contains what
 					params[1], params[2], params[3] = cursor[1], cursor[2] + cursorLightHeight, cursor[3]
@@ -1577,6 +1579,9 @@ function widget:Update(dt)
 						updateLightPosition(cursorPointLightVBO, cursorLights[playerID], cursor[1], cursor[2]+cursorLightHeight, cursor[3])
 					end
 				end
+			elseif cursorLights[playerID] then
+				popElementInstance(cursorPointLightVBO, cursorLights[playerID])
+				cursorLights[playerID] = nil
 			end
 		end
 		uploadAllElements(cursorPointLightVBO)

--- a/luaui/Widgets/gui_advplayerslist.lua
+++ b/luaui/Widgets/gui_advplayerslist.lua
@@ -3364,7 +3364,7 @@ function PingCpuTip(mouseX, pingLvl, cpuLvl, fps, gpumem, luamem, system, name, 
             tipText = tipText .. "    " .. Spring.I18N('ui.playersList.gpuMemory', { gpuUsage = gpumem })
         end
         if luamem ~= nil then
-            tipText = tipText .. "    Lua: " .. luamem .. " MB"
+            tipText = tipText .. "    Lua: " .. luamem .. "MB\n"
         end
         tipTextTitle = (spec and "\255\240\240\240" or colourNames(teamID)) .. name
         if system ~= nil then

--- a/luaui/Widgets/gui_allySelectedUnits.lua
+++ b/luaui/Widgets/gui_allySelectedUnits.lua
@@ -19,6 +19,8 @@ end
 local spGetUnitDefID = Spring.GetUnitDefID
 local spGetGameFrame = Spring.GetGameFrame
 local spGetMyTeamID = Spring.GetMyTeamID
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetGroundHeight = Spring.GetGroundHeight
 
 local showAsSpectator = true
 local selectPlayerUnits = true	-- when lockcamera player
@@ -31,6 +33,9 @@ local enablePlatter = true
 local platterOpacity = 0.1
 
 local useHexagons = true
+local mapHasWater = (Spring.GetGroundExtremes() < 0)
+local nextWaterPassCheckFrame = 0
+local waterPassCheckInterval = 6
 
 ----------------------------------------------------------------------------
 
@@ -39,8 +44,10 @@ local InstanceVBOTable = gl.InstanceVBOTable
 local pushElementInstance = InstanceVBOTable.pushElementInstance
 local popElementInstance  = InstanceVBOTable.popElementInstance
 
-local selectionVBO = nil
+local selectionVBOGround = nil
+local selectionVBOWater = nil
 local selectShader = nil
+local waterShader = nil
 local luaShaderDir = "LuaUI/Include/"
 
 local glStencilFunc         = gl.StencilFunc
@@ -88,6 +95,7 @@ local lockPlayerLastAppliedVersion = -1
 local unitAllyteam = {}
 local spGetUnitTeam = Spring.GetUnitTeam
 local teamAllyTeam = {}
+local unitWaterPass = {}
 
 local function bumpPlayerSelectionVersion(playerID)
 	playerSelectionVersion[playerID] = (playerSelectionVersion[playerID] or 0) + 1
@@ -120,6 +128,45 @@ local instanceCache = {
 			0, 0, 0, 0 -- these are just padding zeros, that will get filled in
 	}
 
+local function getWaterLevel()
+	local lrs = WG.lavaRenderState
+	if lrs and lrs.level then
+		return lrs.level
+	end
+	local level = Spring.GetGameRulesParam("lavaLevel")
+	if level and level ~= -99999 then
+		return level
+	end
+	return 0
+end
+
+local function shouldUseWaterPass(unitID, unitDefID)
+	if not mapHasWater or unitCanFly[unitDefID] then return false end
+	local x, y, z = spGetUnitPosition(unitID)
+	if not x or not y or not z then return false end
+	local waterLevel = getWaterLevel()
+	local groundY = spGetGroundHeight(x, z)
+	return (groundY < waterLevel + 1) and (y <= waterLevel + 20)
+end
+
+local function shouldUseWaterPassAtLevel(unitID, unitDefID, waterLevel)
+	if not mapHasWater or unitCanFly[unitDefID] then return false end
+	local x, y, z = spGetUnitPosition(unitID)
+	if not x or not y or not z then return false end
+	local groundY = spGetGroundHeight(x, z)
+	return (groundY < waterLevel + 1) and (y <= waterLevel + 20)
+end
+
+local function getTargetVBO(unitID, unitDefID)
+	if unitCanFly[unitDefID] then
+		unitWaterPass[unitID] = false
+		return selectionVBOGround
+	end
+	local useWaterPass = shouldUseWaterPass(unitID, unitDefID)
+	unitWaterPass[unitID] = useWaterPass
+	return (useWaterPass and selectionVBOWater) or selectionVBOGround
+end
+
 local function AddPrimitiveAtUnit(unitID)
 	local unitDefID = spGetUnitDefID(unitID)
 	if unitDefID == nil then return end -- these cant be selected
@@ -142,12 +189,16 @@ local function AddPrimitiveAtUnit(unitID)
 		width = radius
 		length = radius
 	end
+	local targetVBO = getTargetVBO(unitID, unitDefID)
+	if targetVBO == nil then
+		return
+	end
 	instanceCache[1], instanceCache[2], instanceCache[3], instanceCache[4] = length, width, cornersize, additionalheight
 	instanceCache[5] = spGetUnitTeam(unitID)
 	instanceCache[7] = spGetGameFrame()
 
 	pushElementInstance(
-		selectionVBO, -- push into this Instance VBO Table
+		targetVBO, -- push into this Instance VBO Table
 		instanceCache,
 		unitID, -- this is the key inside the VBO TAble,
 		true, -- update existing element
@@ -157,9 +208,13 @@ local function AddPrimitiveAtUnit(unitID)
 end
 
 local function RemovePrimitive(unitID)
-	if selectionVBO.instanceIDtoIndex[unitID] then
-		popElementInstance(selectionVBO, unitID)
+	if selectionVBOGround and selectionVBOGround.instanceIDtoIndex[unitID] then
+		popElementInstance(selectionVBOGround, unitID)
 	end
+	if selectionVBOWater and selectionVBOWater.instanceIDtoIndex[unitID] then
+		popElementInstance(selectionVBOWater, unitID)
+	end
+	unitWaterPass[unitID] = nil
 end
 
 local function addUnit(unitID)
@@ -429,7 +484,12 @@ function widget:VisibleUnitRemoved(unitID)
 end
 
 function widget:VisibleUnitsChanged(extVisibleUnits, extNumVisibleUnits)
-	InstanceVBOTable.clearInstanceTable(selectionVBO)
+	if selectionVBOGround then
+		InstanceVBOTable.clearInstanceTable(selectionVBOGround)
+	end
+	if selectionVBOWater then
+		InstanceVBOTable.clearInstanceTable(selectionVBOWater)
+	end
 	for unitID, drawn in pairs(selectedUnits) do
 		removeUnit(unitID)
 	end
@@ -441,6 +501,26 @@ end
 local updateTime = 0
 local checkLockPlayerInterval = 1
 function widget:Update(dt)
+	if mapHasWater and next(selectedUnits) ~= nil then
+		local gf = spGetGameFrame()
+		if gf >= nextWaterPassCheckFrame then
+			nextWaterPassCheckFrame = gf + waterPassCheckInterval
+			local waterLevel = getWaterLevel()
+			for unitID, drawn in pairs(selectedUnits) do
+				if drawn then
+					local unitDefID = spGetUnitDefID(unitID)
+					if unitDefID and not unitCanFly[unitDefID] then
+						local desiredWaterPass = shouldUseWaterPassAtLevel(unitID, unitDefID, waterLevel)
+						if desiredWaterPass ~= unitWaterPass[unitID] then
+							RemovePrimitive(unitID)
+							AddPrimitiveAtUnit(unitID)
+						end
+					end
+				end
+			end
+		end
+	end
+
 	if WG.lockcamera then
 		updateTime = updateTime + dt
 		if updateTime > checkLockPlayerInterval then
@@ -476,10 +556,20 @@ local function init()
 	shaderConfig.LINETRANSPARANCY = lineOpacity
 	shaderConfig.ROTATE_CIRCLES = 0
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(g_color.rgb, TRANSPARENCY + step( 0.01, addRadius) * LINETRANSPARANCY);"
-	selectionVBO, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "allySelectedUnits")
-	if selectionVBO == nil then
+	selectionVBOGround, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "allySelectedUnitsGround")
+	if selectionVBOGround == nil then
 		widgetHandler:RemoveWidget()
 		return false
+	end
+	if mapHasWater then
+		selectionVBOWater, waterShader = InitDrawPrimitiveAtUnit(shaderConfig, "allySelectedUnitsWater")
+		if selectionVBOWater == nil then
+			widgetHandler:RemoveWidget()
+			return false
+		end
+	else
+		selectionVBOWater = nil
+		waterShader = selectShader
 	end
 	return true
 end
@@ -523,6 +613,54 @@ function widget:Shutdown()
 end
 
 local drawFrame = 0
+local function DrawSelections(selectionVBO, shader)
+	if not selectShader then
+		return
+	end
+	if selectionVBO and selectionVBO.usedElements > 0 then
+		shader = shader or selectShader
+		shader:Activate()
+		shader:SetUniform("iconDistance", 99999) -- pass
+		glStencilTest(true) --https://learnopengl.com/Advanced-OpenGL/Stencil-testing
+		glDepthTest(true)
+		glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon		this to the shader
+		glClear(GL_STENCIL_BUFFER_BIT ) -- set stencil buffer to 0
+
+		glStencilFunc(GL_NOTEQUAL, 1, 1) -- use NOTEQUAL instead of ALWAYS to ensure that overlapping transparent fragments dont get written multiple times
+		glStencilMask(1)
+
+		shader:SetUniform("addRadius", 0)
+		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+
+		glStencilFunc(GL_NOTEQUAL, 1, 1)
+		glStencilMask(0)
+		glDepthTest(true)
+
+		shader:SetUniform("addRadius", lineSize)
+		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+
+		glStencilMask(1)
+		glStencilFunc(GL_ALWAYS, 1, 1)
+		glDepthTest(true)
+
+		shader:Deactivate()
+	end
+end
+
+function widget:DrawWorld()
+	if spGetGameFrame() < hideBelowGameframe then return end
+
+	if Spring.IsGUIHidden() then return end
+
+	if enablePlatter then
+		if mapHasWater and selectionVBOWater and selectionVBOWater.usedElements > 0 then
+			DrawSelections(selectionVBOWater, waterShader)
+		elseif not mapHasWater and selectionVBOGround then
+			DrawSelections(selectionVBOGround)
+		end
+	end
+end
+
 function widget:DrawWorldPreUnit()
 	if spGetGameFrame() < hideBelowGameframe then return end
 
@@ -530,33 +668,7 @@ function widget:DrawWorldPreUnit()
 
 	if enablePlatter then
 		drawFrame = drawFrame + 1
-		if selectionVBO.usedElements > 0 then
-			selectShader:Activate()
-			selectShader:SetUniform("iconDistance", 99999) -- pass
-			glStencilTest(true) --https://learnopengl.com/Advanced-OpenGL/Stencil-testing
-			glDepthTest(true)
-			glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon		this to the shader
-			glClear(GL_STENCIL_BUFFER_BIT ) -- set stencil buffer to 0
-
-			glStencilFunc(GL_NOTEQUAL, 1, 1) -- use NOTEQUAL instead of ALWAYS to ensure that overlapping transparent fragments dont get written multiple times
-			glStencilMask(1)
-
-			selectShader:SetUniform("addRadius", 0)
-			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
-
-			glStencilFunc(GL_NOTEQUAL, 1, 1)
-			glStencilMask(0)
-			glDepthTest(true)
-
-			selectShader:SetUniform("addRadius", lineSize)
-			selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
-
-			glStencilMask(1)
-			glStencilFunc(GL_ALWAYS, 1, 1)
-			glDepthTest(true)
-
-			selectShader:Deactivate()
-		end
+		DrawSelections(selectionVBOGround)
 	end
 end
 

--- a/luaui/Widgets/gui_ally_cursors.lua
+++ b/luaui/Widgets/gui_ally_cursors.lua
@@ -20,8 +20,6 @@ local mathAtan2 = math.atan2
 local spGetMyTeamID = Spring.GetMyTeamID
 local spGetSpectatingState = Spring.GetSpectatingState
 
--- TODO: hide (enemy) cursor light when not specfullview
-
 local cursorSize = 11
 local drawNamesCursorSize = 8.5
 
@@ -167,6 +165,29 @@ end
 
 local function isValidCursorPos(pos)
 	return pos and pos[1] >= 0 and pos[2] >= 0
+end
+
+local function GetViewerState()
+	local spectating, currentFullview = spGetSpectatingState()
+	spectating = (spectating == true)
+	currentFullview = (currentFullview == true)
+	fullview = currentFullview
+	myTeamID = spGetMyTeamID()
+	return spectating, currentFullview, myTeamID
+end
+
+local function IsCursorVisibleToViewer(playerID, spectating, currentFullview, viewedTeamID)
+	local teamID = playerTeamIDs[playerID]
+	if not teamID or not viewedTeamID then
+		return false
+	end
+	if currentFullview then
+		return true
+	end
+	if spectating then
+		return teamID == viewedTeamID or spAreTeamsAllied(viewedTeamID, teamID)
+	end
+	return spAreTeamsAllied(viewedTeamID, teamID)
 end
 
 local function MouseCursorEvent(playerID, x1, z1, x2, z2, click)
@@ -327,7 +348,18 @@ function widget:Initialize()
 		if not playerID then
 			return nil
 		end
+		local spectating, currentFullview, viewedTeamID = GetViewerState()
+		if not IsCursorVisibleToViewer(playerID, spectating, currentFullview, viewedTeamID) then
+			return nil, nil
+		end
 		return cursors[playerID], notIdle[playerID]
+	end
+	WG['allycursors'].isCursorVisible = function(playerID)
+		if not playerID then
+			return false
+		end
+		local spectating, currentFullview, viewedTeamID = GetViewerState()
+		return IsCursorVisibleToViewer(playerID, spectating, currentFullview, viewedTeamID)
 	end
 
 	local now = clock() - (idleCursorTime * 0.95)
@@ -604,13 +636,15 @@ function widget:DrawWorldPreUnit()
 		return
 	end
 
+	local spectating, currentFullview, viewedTeamID = GetViewerState()
+
 	glDepthTest(GL.ALWAYS)
 	glBlending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
 	glPolygonOffset(-7, -10)
 
 	for playerID, cursor in pairs(cursors) do
 		if notIdle[playerID] then
-			if fullview or spAreTeamsAllied(myTeamID, playerTeamIDs[playerID]) then
+			if IsCursorVisibleToViewer(playerID, spectating, currentFullview, viewedTeamID) then
 				DrawCursor(playerID, cursor[1], cursor[2], cursor[3], cursor[4], cursor[5], cursor[6], cursor[7])
 			end
 		end

--- a/luaui/Widgets/gui_chat.lua
+++ b/luaui/Widgets/gui_chat.lua
@@ -2917,6 +2917,56 @@ function widget:GameOver()
 	gameOver = true
 end
 
+local function escapePackedField(str)
+	return (tostring(str):gsub("%%", "%%25"):gsub("|", "%%7C"):gsub(";", "%%3B"):gsub("\n", "%%0A"))
+end
+
+local function unescapePackedField(str)
+	if not str or str == "" then
+		return ""
+	end
+	return (str:gsub("%%(%x%x)", function(hex)
+		return string.char(tonumber(hex, 16))
+	end))
+end
+
+local function packOrgLines(lines)
+	if not lines or #lines == 0 then
+		return nil
+	end
+
+	local packed = {}
+	for i = 1, #lines do
+		local entry = lines[i]
+		if type(entry) == "table" and type(entry[1]) == "number" and type(entry[2]) == "string" then
+			packed[#packed + 1] = string.format("%d|%s", entry[1], escapePackedField(entry[2]))
+		end
+	end
+
+	if #packed == 0 then
+		return nil
+	end
+
+	return table.concat(packed, ";")
+end
+
+local function unpackOrgLines(packed)
+	if type(packed) ~= "string" or packed == "" then
+		return nil
+	end
+
+	local lines = {}
+	for record in string.gmatch(packed, "([^;]+)") do
+		local frameStr, packedText = string.match(record, "^([^|]+)|(.+)$")
+		local frame = tonumber(frameStr)
+		if frame and packedText then
+			lines[#lines + 1] = { frame, unescapePackedField(packedText) }
+		end
+	end
+
+	return lines
+end
+
 function widget:GetConfigData(data)
 	local inputHistoryLimited = {}
 	for k,v in ipairs(inputHistory) do
@@ -2937,7 +2987,8 @@ function widget:GetConfigData(data)
 	return {
 		gameFrame = Spring.GetGameFrame(),
 		gameID = Game.gameID and Game.gameID or Spring.GetGameRulesParam("GameID"),
-		orgLines = gameOver and nil or orgLines,
+		orgLinesPacked = gameOver and nil or packOrgLines(orgLines),
+		orgLinesPackedFormat = 1,
 		inputHistory = inputHistoryLimited,
 		maxLines = maxLines,
 		maxConsoleLines = maxConsoleLines,
@@ -2958,18 +3009,19 @@ function widget:GetConfigData(data)
 end
 
 function widget:SetConfigData(data)
-	if data.orgLines ~= nil then
+	local loadedOrgLines = unpackOrgLines(data.orgLinesPacked) or data.orgLines
+	if loadedOrgLines ~= nil then
 		if Spring.GetGameFrame() > 0 or (data.gameID and data.gameID == (Game.gameID and Game.gameID or Spring.GetGameRulesParam("GameID"))) then
 			if data.playernames then
 				playernames = data.playernames
 			end
-			orgLines = data.orgLines
+			orgLines = loadedOrgLines
 			if data.soundErrors then
 				soundErrors = data.soundErrors
 			end
 		elseif data.gameID then
 			prevGameID = data.gameID
-			prevOrgLines = data.orgLines
+			prevOrgLines = loadedOrgLines
 		end
 	end
 	if data.inputHistory ~= nil then

--- a/luaui/Widgets/gui_ecostats.lua
+++ b/luaui/Widgets/gui_ecostats.lua
@@ -94,6 +94,7 @@ local textLists = {}
 local avgData = {}
 local uiElementRects = {}
 local tooltipAreas = {}
+local teamTooltipAreas = {}
 local guishaderRects = {}
 local guishaderRectsDlists = {}
 local guishaderWasActive = false
@@ -118,6 +119,7 @@ local isReplay = spIsReplay()
 local myAllyID = spGetLocalAllyTeamID()
 local vsx, vsy = spGetViewGeometry()
 local topbarShowButtons = true
+local prevTopbar = false
 
 local sin = mathSin
 local floor = mathFloor
@@ -316,11 +318,12 @@ end
 local function updateDrawPos()
 	local drawpos = 0
 	aliveAllyTeams = 0
+	local currentMyAllyID = spGetMyAllyTeamID()
 	if WG.allyTeamRanking then
 		for _, allyID in pairs(WG.allyTeamRanking) do
 			local dataID = allyIDdata[allyID]
 			if allyData[dataID] then
-				if isTeamReal(allyID) and (allyID == spGetMyAllyTeamID() or inSpecMode) and allyData[dataID].isAlive then
+				if isTeamReal(allyID) and (allyID == currentMyAllyID or inSpecMode) and allyData[dataID].isAlive then
 					aliveAllyTeams = aliveAllyTeams + 1
 					drawpos = drawpos + 1
 					allyData[dataID].drawpos = drawpos
@@ -330,7 +333,7 @@ local function updateDrawPos()
 	else
 		for _, data in ipairs(allyData) do
 			local allyID = data.aID
-			if isTeamReal(allyID) and (allyID == spGetMyAllyTeamID() or inSpecMode) and data.isAlive then
+			if isTeamReal(allyID) and (allyID == currentMyAllyID or inSpecMode) and data.isAlive then
 				aliveAllyTeams = aliveAllyTeams + 1
 				drawpos = drawpos + 1
 			end
@@ -673,10 +676,11 @@ function widget:Initialize()
 end
 
 local function removeGuiShaderRects()
+	local currentMyAllyID = spGetMyAllyTeamID()
 	if WG['guishader'] then
 		for _, data in pairs(allyData) do
 			local aID = data.aID
-			if isTeamReal(aID) and (aID == spGetMyAllyTeamID() or inSpecMode) and aID ~= gaiaAllyID then
+			if isTeamReal(aID) and (aID == currentMyAllyID or inSpecMode) and aID ~= gaiaAllyID then
 				local key = eco.ecoKey[aID] or ('ecostats_' .. aID)
 				WG['guishader'].DeleteDlist(key)
 				guishaderRectsDlists[key] = nil
@@ -688,14 +692,16 @@ local function removeGuiShaderRects()
 	if WG['tooltip'] ~= nil then
 		for _, data in pairs(allyData) do
 			local aID = data.aID
-			if isTeamReal(aID) and (aID == spGetMyAllyTeamID() or inSpecMode) and (aID ~= gaiaAllyID) then
+			if isTeamReal(aID) and (aID == currentMyAllyID or inSpecMode) and (aID ~= gaiaAllyID) then
 				local key = eco.ecoKey[aID] or ('ecostats_' .. aID)
 				if tooltipAreas[key] ~= nil then
 					WG['tooltip'].RemoveTooltip(key)
 					tooltipAreas[key] = nil
 					local teams = Spring.GetTeamList(aID)
 					for _, tID in ipairs(teams) do
-						WG['tooltip'].RemoveTooltip(eco.ecoTeamKey[tID] or ('ecostats_team_' .. tID))
+						local teamKey = eco.ecoTeamKey[tID] or ('ecostats_team_' .. tID)
+						WG['tooltip'].RemoveTooltip(teamKey)
+						teamTooltipAreas[teamKey] = nil
 					end
 				end
 			end
@@ -718,17 +724,19 @@ end
 
 local areaRect = {}
 local prevAreaRect = {}
+local uiElementRectsCount = 0
 local function makeTeamCompositionList()
 	if not inSpecMode then
 		return
 	end
-	if #uiElementRects == 0 then
+	if uiElementRectsCount == 0 then
 		DrawTeamComposition()	-- need to run once so uiElementRects gets filled
 	end
-	areaRect = {}
-	for id, rect in pairs(uiElementRects) do
+	areaRect[1], areaRect[2], areaRect[3], areaRect[4] = nil, nil, nil, nil
+	for i = 1, uiElementRectsCount do
+		local rect = uiElementRects[i]
 		if not areaRect[1] then
-			areaRect = { rect[1], rect[2], rect[3], rect[4] }
+			areaRect[1], areaRect[2], areaRect[3], areaRect[4] = rect[1], rect[2], rect[3], rect[4]
 		else
 			if rect[1] < areaRect[1] then
 				areaRect[1] = rect[1]
@@ -748,7 +756,7 @@ local function makeTeamCompositionList()
 	if not prevAreaRect[1] or (areaRect[1] ~= prevAreaRect[1] or areaRect[2] ~= prevAreaRect[2] or areaRect[3] ~= prevAreaRect[3] or areaRect[4] ~= prevAreaRect[4]) then
 		rectAreaChange = true
 	end
-	prevAreaRect = areaRect
+	prevAreaRect[1], prevAreaRect[2], prevAreaRect[3], prevAreaRect[4] = areaRect[1], areaRect[2], areaRect[3], areaRect[4]
 
 	local texWidth = areaRect[1] and areaRect[3] and mathFloor(areaRect[3]-areaRect[1]) or 0
 	local texHeight = areaRect[2] and areaRect[4] and mathFloor(areaRect[4]-areaRect[2]) or 0
@@ -772,7 +780,8 @@ local function makeTeamCompositionList()
 	end
 	if uiBgTex and areaRect[4] then
 		gl.R2tHelper.RenderInRect(uiBgTex, areaRect[1], areaRect[2], areaRect[3], areaRect[4], function()
-			for id, rect in pairs(uiElementRects) do
+			for i = 1, uiElementRectsCount do
+				local rect = uiElementRects[i]
 				UiElement(rect[1], rect[2], rect[3], rect[4], (widgetPosY+widgetHeight > rect[4]+1 and 1 or 0), 0, 0, 1, 0, 1, 1, 1, nil, nil, nil, nil)
 			end
 		end, true)
@@ -837,7 +846,8 @@ local function Reinit()
 		end
 	end
 
-	uiElementRects = {}
+	uiElementRectsCount = 0
+	teamTooltipAreas = {}
 
 	processScaling()
 	UpdateAllTeams()
@@ -1005,21 +1015,34 @@ local bgArea = {0, 0, 0, 0}
 local function DrawBackground(posY, allyID, teamWidth)
 	local y1 = mathCeil((widgetPosY - posY) + widgetHeight)
 	local y2 = mathCeil((widgetPosY - posY) + tH + widgetHeight)
+	local x1 = widgetPosX + teamWidth
+	local x2 = widgetPosX + widgetWidth
 
-	uiElementRects[#uiElementRects+1] = { widgetPosX + teamWidth, y1, widgetPosX + widgetWidth, y2, allyID }
+	uiElementRectsCount = uiElementRectsCount + 1
+	local rect = uiElementRects[uiElementRectsCount]
+	if rect == nil then
+		rect = {0, 0, 0, 0, 0}
+		uiElementRects[uiElementRectsCount] = rect
+	end
+	rect[1], rect[2], rect[3], rect[4], rect[5] = x1, y1, x2, y2, allyID
 
 	local key = eco.ecoKey[allyID]
-	guishaderRects[key] = { widgetPosX + teamWidth, y1, widgetPosX + widgetWidth, y2, 4 * widgetScale }
+	local gsRect = guishaderRects[key]
+	if gsRect == nil then
+		gsRect = {0, 0, 0, 0, 0}
+		guishaderRects[key] = gsRect
+	end
+	gsRect[1], gsRect[2], gsRect[3], gsRect[4], gsRect[5] = x1, y1, x2, y2, 4 * widgetScale
 
 	local areaX1 = widgetPosX + (widgetWidth / 12)
-	local areaKey = areaX1 * 1000000000 + y1 * 1000000 + (widgetPosX + widgetWidth) * 1000 + y2
+	local areaKey = areaX1 * 1000000000 + y1 * 1000000 + x2 * 1000 + y2
 	if WG['tooltip'] ~= nil and (tooltipAreas[key] == nil or tooltipAreas[key] ~= areaKey or refreshCaptions) then
 		refreshCaptions = false
 		if not cachedTooltipText then
 			cachedTooltipText = Spring.I18N('ui.teamEconomy.tooltip')
 			cachedTooltipTitle = Spring.I18N('ui.teamEconomy.tooltipTitle')
 		end
-		bgArea[1], bgArea[2], bgArea[3], bgArea[4] = areaX1, y1, widgetPosX + widgetWidth, y2
+		bgArea[1], bgArea[2], bgArea[3], bgArea[4] = areaX1, y1, x2, y2
 		WG['tooltip'].AddTooltip(key, bgArea, cachedTooltipText, nil, cachedTooltipTitle)
 		tooltipAreas[key] = areaKey
 	end
@@ -1097,8 +1120,13 @@ local function DrawTeamCompositionTeam(hOffset, vOffset, r, g, b, a, small, mous
 		btn.pID = tID
 	end
 	if WG['tooltip'] then
-		tctArea[1], tctArea[2], tctArea[3], tctArea[4] = x1, y1, x2, y2
-		WG['tooltip'].AddTooltip(eco.ecoTeamKey[tID], tctArea, teamData[tID].leaderName)
+		local tipKey = eco.ecoTeamKey[tID] or ('ecostats_team_' .. tID)
+		local areaKey = x1 * 1000000000 + y1 * 1000000 + x2 * 1000 + y2
+		if teamTooltipAreas[tipKey] ~= areaKey or refreshCaptions then
+			tctArea[1], tctArea[2], tctArea[3], tctArea[4] = x1, y1, x2, y2
+			WG['tooltip'].AddTooltip(tipKey, tctArea, teamData[tID].leaderName)
+			teamTooltipAreas[tipKey] = areaKey
+		end
 	end
 
 	tctColorBot[1], tctColorBot[2], tctColorBot[3] = r * 0.75, g * 0.75, b * 0.75
@@ -1113,45 +1141,53 @@ end
 function DrawTeamComposition()
 	-- do dynamic stuff without display list
 	local t = spGetGameSeconds()
-	uiElementRects = {}
+	local tPositive = t > 0
+	local rowOffset = 4 * sizeMultiplier
+	local iconOffset = floor(tH * 0.125)
+	local badge03 = WBadge * 0.3
+	local teamWidthAdjust = floor((playerScale - 1) * 14)
+	local currentMyAllyID = myAllyID
+	uiElementRectsCount = 0
 	for _, data in pairs(allyData) do
 		local aID = data.aID
 		local drawpos = data.drawpos
-		if data.exists and drawpos and (aID == myAllyID or inSpecMode) and (aID ~= gaiaAllyID) and data.isAlive and isTeamReal(aID) then
-
-			local posy = tH * (drawpos) + (4 * sizeMultiplier)
-			local hasCom
+		if data.exists and drawpos and (aID == currentMyAllyID or inSpecMode) and (aID ~= gaiaAllyID) and data.isAlive and isTeamReal(aID) then
+			local posy = tH * drawpos + rowOffset
+			local teams = data.teams
+			local teamsLen = #teams
 
 			local teamWidth = 0
-			for i, tID in pairs(data.teams) do
-				if tID ~= gaiaID then
-					teamWidth = -(WBadge * (i)) - (WBadge * 0.3)
+			if teamsLen > 0 then
+				if teams[teamsLen] ~= gaiaID then
+					teamWidth = -(WBadge * teamsLen) - badge03
+				else
+					for i = teamsLen - 1, 1, -1 do
+						if teams[i] ~= gaiaID then
+							teamWidth = -(WBadge * i) - badge03
+							break
+						end
+					end
 				end
 			end
-			teamWidth = teamWidth + floor((playerScale-1)*14)
+			teamWidth = teamWidth + teamWidthAdjust
 
-			if type(data.tE) == "number" and drawpos and #(data.teams) > 0 then
-				DrawBackground(posy - (4 * sizeMultiplier), aID, mathFloor(teamWidth))
+			if data.tE ~= nil and teamsLen > 0 then
+				DrawBackground(posy - rowOffset, aID, mathFloor(teamWidth))
 			end
 
 			-- team rectangles
-			for i, tID in pairs(data.teams) do
+			for i = 1, teamsLen do
+				local tID = teams[i]
 				if tID ~= gaiaID then
 					local tData = teamData[tID]
 					local r = tData.red or 1
 					local g = tData.green or 1
 					local b = tData.blue or 1
-					local alpha
-					local posx = floor(-(WBadge * (i - 1)) + (WBadge * 0.3))
-					hasCom = tData.hasCom
-					if t > 0 then
-						if not tData.isDead then
-							alpha = tData.active and 1 or 0.3
-							DrawTeamCompositionTeam(posx, posy + floor(tH * 0.125), r, g, b, alpha, not hasCom, Button[tID].mouse, t, false, tID)
-						else
-							alpha = 0.8
-							DrawTeamCompositionTeam(posx, posy + floor(tH * 0.125), r, g, b, alpha, true, Button[tID].mouse, t, true, tID) --dead, big icon
-						end
+					local posx = floor(-(WBadge * (i - 1)) + badge03)
+					if tPositive then
+						local isDead = tData.isDead
+						local alpha = isDead and 0.8 or (tData.active and 1 or 0.3)
+						DrawTeamCompositionTeam(posx, posy + iconOffset, r, g, b, alpha, isDead or not tData.hasCom, Button[tID].mouse, t, isDead, tID)
 					else
 						DrawBox(posx, posy, r, g, b)
 					end
@@ -1162,20 +1198,20 @@ function DrawTeamComposition()
 end
 
 local gameSeconds = 0
-local function drawListStandard()
+local function drawListStandard(now)
 	if not gamestarted then
 		updateButtons()
 	end
 
 	gameSeconds = spGetGameSeconds()
 	local updateTextLists = false
-	local currentTime = osClock()
+	local currentTime = now or osClock()
 	if currentTime > lastTextListUpdate + 0.5 then
 		updateTextLists = true
 		lastTextListUpdate = currentTime
 	end
 
-	if currentTime > lastBarsUpdate + 0.15 then
+	if now or currentTime > lastBarsUpdate + 0.15 then
 		lastBarsUpdate = currentTime
 		maxMetal, maxEnergy = 0, 0
 		local allyDataLen = #allyData
@@ -1285,6 +1321,7 @@ function widget:PlayerChanged(playerID)
 	end
 	myFullview = select(2, spGetSpectatingState())
 	myTeamID = spGetMyTeamID()
+	myAllyID = spGetMyAllyTeamID()
 
 	if myFullview then
 		lastPlayerChange = spGetGameFrame()
@@ -1429,6 +1466,7 @@ end
 local sec = 0
 local sec1 = 0
 local sec2 = 0
+local secButtons = 0
 function widget:Update(dt)
 	if not inSpecMode or not myFullview then
 		return
@@ -1465,8 +1503,13 @@ function widget:Update(dt)
 			data.einc = select(4, spGetTeamResources(teamID, "energy")) or 0
 			data.erecl, data.mrecl = getTeamReclaim(teamID)
 		end
-		updateButtons()
 		UpdateAllies()
+	end
+
+	secButtons = secButtons + dt
+	if secButtons > 1 then
+		secButtons = 0
+		updateButtons()
 	end
 
 	sec = sec + dt
@@ -1502,7 +1545,7 @@ local r2tDrawFunc = function()
 	gl.Scale(2 / (areaRect[3]-areaRect[1]), 2 / (areaRect[4]-areaRect[2]), 0)
 	gl.Translate(-areaRect[1], -areaRect[2], 0)
 	DrawTeamComposition()
-	drawListStandard()
+	drawListStandard(eco.drawNow)
 end
 
 local r2tScissors = {0, 0, 0, 0}  -- reusable
@@ -1530,6 +1573,7 @@ function widget:DrawScreen()
 	if uiTex then
 		local now = osClock()
 		if now > lastBarsUpdate + 0.15 then
+			eco.drawNow = now
 			local scissors
 			if cfgResText and now <= lastTextListUpdate + 0.5 then
 				-- only clean non text area

--- a/luaui/Widgets/gui_rejoinprogress.lua
+++ b/luaui/Widgets/gui_rejoinprogress.lua
@@ -36,9 +36,45 @@ local rejoinArea = {}
 local gameStarted = (spGetGameFrame() > 0)
 local isReplay = Spring.IsReplay()
 local RectRound, TexturedRectRound, UiElement, font2
-local dlistRejoin, dlistRejoinGuishader, serverFrame
+local dlistRejoinStatic, dlistRejoinGuishader, serverFrame
 local posY = 0.22
 local width, height
+local currentCatchup = 0
+local barHeight, barWidth, edgeWidth, addedSize, glowSize, fontsize, stripesTexScale
+
+-- Reused tables to avoid per-update allocations while rebuilding display lists.
+local barArea = { 0, 0, 0, 0 }
+local colorBlack03 = { 0, 0, 0, 0.03 }
+local colorDark20 = { 0.15, 0.15, 0.15, 0.2 }
+local colorLight16 = { 0.8, 0.8, 0.8, 0.16 }
+local colorWhite0 = { 1, 1, 1, 0 }
+local colorWhite007 = { 1, 1, 1, 0.07 }
+local colorWhite01 = { 1, 1, 1, 0.1 }
+local colorWhite013 = { 1, 1, 1, 0.13 }
+local colorZero0 = { 0, 0, 0, 0 }
+local colorGreenDark = { 0, 0.55, 0, 1 }
+local colorGreenBright = { 0, 1, 0, 1 }
+
+local catchingUpText = Spring.I18N('ui.rejoin.catchingUp')
+local lastGameTimeText = nil
+local cachedTitleText = nil
+
+local function deleteStaticDList()
+	if dlistRejoinStatic ~= nil then
+		gl.DeleteList(dlistRejoinStatic)
+		dlistRejoinStatic = nil
+	end
+end
+
+local function deleteGuiShaderDList()
+	if dlistRejoinGuishader ~= nil then
+		if WG['guishader'] then
+			WG['guishader'].RemoveDlist('rejoinprogress')
+		end
+		gl.DeleteList(dlistRejoinGuishader)
+		dlistRejoinGuishader = nil
+	end
+end
 
 local function RectQuad(px, py, sx, sy, offset)
 	gl.TexCoord(offset, 1 - offset)
@@ -54,94 +90,105 @@ local function DrawRect(px, py, sx, sy, zoom)
 	gl.BeginEnd(GL.QUADS, RectQuad, px, py, sx, sy, zoom)
 end
 
-local function updateRejoin()
+local function buildStaticRejoin()
+	local area = rejoinArea
 
-	if showRejoinUI and serverFrame then
-		local area = rejoinArea
-		local catchup = spGetGameFrame() / serverFrame
-		if not dlistRejoinGuishader then
-			dlistRejoinGuishader = gl.CreateList(function()
-				RectRound(area[1], area[2], area[3], area[4], 5.5 * widgetScale, 0,0,1,1)
-			end)
-			if WG['guishader'] then
-				WG['guishader'].InsertDlist(dlistRejoinGuishader, 'rejoinprogress')
-			end
-		end
-
-		if dlistRejoin ~= nil then
-			gl.DeleteList(dlistRejoin)
-		end
-		dlistRejoin = gl.CreateList(function()
-			UiElement(area[1], area[2], area[3], area[4], 1, 1, 1, 1)
-
-			local barHeight = mathFloor((height * widgetScale / 7.5) + 0.5)
-			local barHeightPadding = 1+mathFloor(vsy*0.007)
-			local barLeftPadding = barHeightPadding
-			local barRightPadding = barHeightPadding
-			local barArea = { area[1] + barLeftPadding, area[2] + barHeightPadding, area[3] - barRightPadding, area[2] + barHeight + barHeightPadding }
-			local barWidth = barArea[3] - barArea[1]
-
-			-- Bar background
-			local edgeWidth = math.max(1, mathFloor(vsy / 1100))
-			local addedSize = mathFloor(((barArea[4] - barArea[2]) * 0.15) + 0.5)
-			RectRound(barArea[1] - addedSize - edgeWidth, barArea[2] - addedSize - edgeWidth, barArea[3] + addedSize + edgeWidth, barArea[4] + addedSize + edgeWidth, barHeight * 0.33, 1, 1, 1, 1, { 0, 0, 0, 0.03 }, { 0, 0, 0, 0.03 })
-			RectRound(barArea[1] - addedSize, barArea[2] - addedSize, barArea[3] + addedSize, barArea[4] + addedSize, barHeight * 0.33, 1, 1, 1, 1, { 0.15, 0.15, 0.15, 0.2 }, { 0.8, 0.8, 0.8, 0.16 })
-
-			gl.Texture(noiseBackgroundTexture)
-			gl.Color(1,1,1, 0.12)
-			TexturedRectRound(barArea[1] - addedSize - edgeWidth, barArea[2] - addedSize - edgeWidth, barArea[3] + addedSize + edgeWidth, barArea[4] + addedSize + edgeWidth, barHeight * 0.33, barWidth*0.6, 0)
-			gl.Texture(false)
-
-			-- gloss
-			gl.Blending(GL.SRC_ALPHA, GL.ONE)
-			RectRound(barArea[1] - addedSize, barArea[2] + addedSize, barArea[3] + addedSize, barArea[4] + addedSize, barHeight * 0.33, 1, 1, 0, 0, { 1, 1, 1, 0 }, { 1, 1, 1, 0.07 })
-			RectRound(barArea[1] - addedSize, barArea[2] - addedSize, barArea[3] + addedSize, barArea[2] + addedSize + addedSize + addedSize, barHeight * 0.2, 0, 0, 1, 1, { 1, 1, 1, 0.1 }, { 1, 1, 1, 0.0 })
-			gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
-
-			-- Bar value
-			local valueWidth = catchup * barWidth
-			gl.Color(0, 1, 0, 1)
-			RectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, { 0, 0.55, 0, 1 }, { 0, 1, 0, 1 })
-
-			gl.Texture(stripesTexture)
-			gl.Color(1,1,1, 0.16)
-			TexturedRectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, (barArea[3]-barArea[1]) * 0.22, - os.clock()*0.06)
-
-			gl.Texture(noiseBackgroundTexture)
-			gl.Color(1,1,1, 0.07)
-			TexturedRectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, barWidth*0.6, 0)
-			gl.Texture(false)
-
-			-- Bar value highlight
-			gl.Blending(GL.SRC_ALPHA, GL.ONE)
-			RectRound(barArea[1], barArea[4] - ((barArea[4] - barArea[2]) / 1.5), barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, { 0, 0, 0, 0 }, { 1, 1, 1, 0.13 })
-			RectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[2] + ((barArea[4] - barArea[2]) / 2), barHeight * 0.2, 1, 1, 1, 1, { 1, 1, 1, 0.13 }, { 0, 0, 0, 0 })
-
-			-- Bar value glow
-			local glowSize = barHeight * 6
-			gl.Color(0, 1, 0, 0.08)
-			gl.Texture(barGlowCenterTexture)
-			DrawRect(barArea[1], barArea[2] - glowSize, barArea[1] + (catchup * barWidth), barArea[4] + glowSize, 0.008)
-			gl.Texture(barGlowEdgeTexture)
-			DrawRect(barArea[1] - (glowSize * 2), barArea[2] - glowSize, barArea[1], barArea[4] + glowSize, 0.008)
-			DrawRect((barArea[1] + (catchup * barWidth)) + (glowSize * 2), barArea[2] - glowSize, barArea[1] + (catchup * barWidth), barArea[4] + glowSize, 0.008)
-			gl.Texture(false)
-			gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
-			gl.Color(1,1,1,1)
-
-			local mins = mathFloor(serverFrame / 30 / 60)
-			local secs = mathFloor(((serverFrame / 30 / 60) - mins) * 60)
-			local gametime = mins..':'..(secs < 10 and '0'..secs or secs)
-
-			-- Text
-			local fontsize = mathFloor(height*0.34)
-			font2:Begin()
-			font2:SetTextColor(0.92, 0.92, 0.92, 1)
-			font2:SetOutlineColor(0, 0, 0, 1)
-			font2:Print('\255\225\255\225' .. Spring.I18N('ui.rejoin.catchingUp') .. ' \255\166\166\166'..gametime, area[1] + ((area[3] - area[1]) / 2), area[2] + barHeight * 2 + (fontsize*0.89), fontsize, 'cor')
-			font2:End()
+	if not dlistRejoinGuishader then
+		dlistRejoinGuishader = gl.CreateList(function()
+			RectRound(area[1], area[2], area[3], area[4], 5.5 * widgetScale, 0,0,1,1)
 		end)
+		if WG['guishader'] then
+			WG['guishader'].InsertDlist(dlistRejoinGuishader, 'rejoinprogress')
+		end
 	end
+
+	deleteStaticDList()
+	dlistRejoinStatic = gl.CreateList(function()
+		UiElement(area[1], area[2], area[3], area[4], 1, 1, 1, 1)
+
+		RectRound(barArea[1] - addedSize - edgeWidth, barArea[2] - addedSize - edgeWidth, barArea[3] + addedSize + edgeWidth, barArea[4] + addedSize + edgeWidth, barHeight * 0.33, 1, 1, 1, 1, colorBlack03, colorBlack03)
+		RectRound(barArea[1] - addedSize, barArea[2] - addedSize, barArea[3] + addedSize, barArea[4] + addedSize, barHeight * 0.33, 1, 1, 1, 1, colorDark20, colorLight16)
+
+		gl.Texture(noiseBackgroundTexture)
+		gl.Color(1,1,1, 0.12)
+		TexturedRectRound(barArea[1] - addedSize - edgeWidth, barArea[2] - addedSize - edgeWidth, barArea[3] + addedSize + edgeWidth, barArea[4] + addedSize + edgeWidth, barHeight * 0.33, barWidth*0.6, 0)
+		gl.Texture(false)
+
+		gl.Blending(GL.SRC_ALPHA, GL.ONE)
+		RectRound(barArea[1] - addedSize, barArea[2] + addedSize, barArea[3] + addedSize, barArea[4] + addedSize, barHeight * 0.33, 1, 1, 0, 0, colorWhite0, colorWhite007)
+		RectRound(barArea[1] - addedSize, barArea[2] - addedSize, barArea[3] + addedSize, barArea[2] + addedSize + addedSize + addedSize, barHeight * 0.2, 0, 0, 1, 1, colorWhite01, colorWhite0)
+		gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+		gl.Color(1,1,1,1)
+	end)
+end
+
+local function updateGeometry()
+	local area = rejoinArea
+	local barHeightPadding = 1 + mathFloor(vsy * 0.007)
+	barHeight = mathFloor((height * widgetScale / 7.5) + 0.5)
+	barArea[1] = area[1] + barHeightPadding
+	barArea[2] = area[2] + barHeightPadding
+	barArea[3] = area[3] - barHeightPadding
+	barArea[4] = area[2] + barHeight + barHeightPadding
+	barWidth = barArea[3] - barArea[1]
+	edgeWidth = math.max(1, mathFloor(vsy / 1100))
+	addedSize = mathFloor(((barArea[4] - barArea[2]) * 0.15) + 0.5)
+	glowSize = barHeight * 6
+	fontsize = mathFloor(height * 0.34)
+	stripesTexScale = barWidth * 0.22
+end
+
+local function updateRejoinText()
+	local mins = mathFloor(serverFrame / 30 / 60)
+	local secs = mathFloor(((serverFrame / 30 / 60) - mins) * 60)
+	local gametime = mins .. ':' .. (secs < 10 and '0' .. secs or secs)
+	if gametime ~= lastGameTimeText then
+		lastGameTimeText = gametime
+		cachedTitleText = '\255\225\255\225' .. catchingUpText .. ' \255\166\166\166' .. gametime
+	end
+end
+
+local function updateRejoinState()
+	if showRejoinUI and serverFrame then
+		currentCatchup = spGetGameFrame() / serverFrame
+		updateRejoinText()
+	end
+end
+
+local function drawRejoinDynamic()
+	local valueWidth = currentCatchup * barWidth
+
+	gl.Color(0, 1, 0, 1)
+	RectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, colorGreenDark, colorGreenBright)
+
+	gl.Texture(stripesTexture)
+	gl.Color(1,1,1, 0.16)
+	TexturedRectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, stripesTexScale, - os.clock() * 0.06)
+
+	gl.Texture(noiseBackgroundTexture)
+	gl.Color(1,1,1, 0.07)
+	TexturedRectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[4], barHeight * 0.2, barWidth*0.6, 0)
+	gl.Texture(false)
+
+	gl.Blending(GL.SRC_ALPHA, GL.ONE)
+	RectRound(barArea[1], barArea[4] - ((barArea[4] - barArea[2]) / 1.5), barArea[1] + valueWidth, barArea[4], barHeight * 0.2, 1, 1, 1, 1, colorZero0, colorWhite013)
+	RectRound(barArea[1], barArea[2], barArea[1] + valueWidth, barArea[2] + ((barArea[4] - barArea[2]) / 2), barHeight * 0.2, 1, 1, 1, 1, colorWhite013, colorZero0)
+
+	gl.Color(0, 1, 0, 0.08)
+	gl.Texture(barGlowCenterTexture)
+	DrawRect(barArea[1], barArea[2] - glowSize, barArea[1] + valueWidth, barArea[4] + glowSize, 0.008)
+	gl.Texture(barGlowEdgeTexture)
+	DrawRect(barArea[1] - (glowSize * 2), barArea[2] - glowSize, barArea[1], barArea[4] + glowSize, 0.008)
+	DrawRect((barArea[1] + valueWidth) + (glowSize * 2), barArea[2] - glowSize, barArea[1] + valueWidth, barArea[4] + glowSize, 0.008)
+	gl.Texture(false)
+	gl.Blending(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)
+	gl.Color(1,1,1,1)
+
+	font2:Begin()
+	font2:SetTextColor(0.92, 0.92, 0.92, 1)
+	font2:SetOutlineColor(0, 0, 0, 1)
+	font2:Print(cachedTitleText, rejoinArea[1] + ((rejoinArea[3] - rejoinArea[1]) / 2), rejoinArea[2] + barHeight * 2 + (fontsize*0.89), fontsize, 'cor')
+	font2:End()
 end
 
 function widget:Update(dt)
@@ -166,25 +213,24 @@ function widget:Update(dt)
 
 			local framesLeft = serverFrame - spGetGameFrame()
 			if framesLeft > CATCH_UP_THRESHOLD then
-				showRejoinUI = true
-				updateRejoin()
+				if not showRejoinUI then
+					showRejoinUI = true
+					buildStaticRejoin()
+				end
+				updateRejoinState()
 			elseif showRejoinUI then
 				showRejoinUI = false
-				if dlistRejoinGuishader ~= nil then
-					if WG['guishader'] then
-						WG['guishader'].RemoveDlist('rejoinprogress')
-					end
-					gl.DeleteList(dlistRejoinGuishader)
-					dlistRejoinGuishader = nil
-				end
+				deleteStaticDList()
+				deleteGuiShaderDList()
 			end
 		end
 	end
 end
 
 function widget:DrawScreen()
-	if dlistRejoin and showRejoinUI then
-		gl.CallList(dlistRejoin)
+	if dlistRejoinStatic and showRejoinUI then
+		gl.CallList(dlistRejoinStatic)
+		drawRejoinDynamic()
 	end
 end
 
@@ -202,16 +248,14 @@ function widget:ViewResize()
 	font2 = WG['fonts'].getFont(2)
 
 	rejoinArea = { mathFloor(0.5*vsx)-mathFloor(width*0.5), mathFloor(posY*vsy)-mathFloor(height*0.5), mathFloor(0.5*vsx) + mathFloor(width*0.5), mathFloor(posY*vsy)+mathFloor(height*0.5) }
+	updateGeometry()
+	deleteStaticDList()
+	deleteGuiShaderDList()
 
-	if dlistRejoinGuishader ~= nil then
-		if WG['guishader'] then
-			WG['guishader'].RemoveDlist('rejoinprogress')
-		end
-		gl.DeleteList(dlistRejoinGuishader)
-		dlistRejoinGuishader = nil
+	if showRejoinUI and serverFrame then
+		buildStaticRejoin()
+		updateRejoinState()
 	end
-
-	updateRejoin()
 end
 
 -- used for rejoin progress functionality
@@ -242,11 +286,7 @@ function widget:Initialize()
 end
 
 function widget:Shutdown()
-	if dlistRejoin ~= nil then
-		gl.DeleteList(dlistRejoin)
-	end
-	if dlistRejoinGuishader ~= nil and WG['guishader'] then
-		WG['guishader'].RemoveDlist('rejoinprogress')
-	end
+	deleteStaticDList()
+	deleteGuiShaderDList()
 	WG['rejoin'] = nil
 end

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -49,6 +49,7 @@ local mapHasWater = (Spring.GetGroundExtremes() < 0)
 
 local selectShader = nil
 local unbuiltShader = nil
+local waterShader = nil
 local luaShaderDir = "LuaUI/Include/"
 
 local InstanceVBOTable = gl.InstanceVBOTable
@@ -57,7 +58,6 @@ local pushElementInstance = InstanceVBOTable.pushElementInstance
 local popElementInstance  = InstanceVBOTable.popElementInstance
 
 
-local hasBadCulling = ((Platform.gpuVendor == "AMD" and Platform.osFamily == "Linux") == true)
 -- Localize for speedups:
 local glStencilFunc         = gl.StencilFunc
 local glStencilOp           = gl.StencilOp
@@ -232,9 +232,9 @@ end
 
 local function DrawSelections(selectionVBO, shader)
 	if selectionVBO.usedElements > -1 then
-		if hasBadCulling then
-			gl.Culling(false)
-		end
+		-- DrawWorld can inherit culling state from other render passes/widgets.
+		-- Force culling off so platter winding/order differences cannot hide them.
+		gl.Culling(false)
 
 		shader = shader or selectShader
 
@@ -278,7 +278,7 @@ end
 if mapHasWater then
 	function widget:DrawWorld()
 		-- Water-affected ground platters are drawn post-water to avoid refraction distortion.
-		DrawSelections(selectionVBOWater)
+		DrawSelections(selectionVBOWater, waterShader)
 		DrawSelections(selectionVBOUnfinished, unbuiltShader)
 	end
 else
@@ -525,10 +525,11 @@ local function init()
 	selectionVBOUnfinished, unbuiltShader = InitDrawPrimitiveAtUnit(unbuiltConfig, "selectedUnitsUnfinished")
 
 	if mapHasWater then
-		selectionVBOWater = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsWater")
+		selectionVBOWater, waterShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnitsWater")
 		selectionVBOAir = selectionVBOGround
 	else
 		selectionVBOWater = selectionVBOGround
+		waterShader = selectShader
 		selectionVBOAir = selectionVBOGround
 	end
 	ClearLastMouseOver()

--- a/luaui/Widgets/gui_selectedunits_gl4.lua
+++ b/luaui/Widgets/gui_selectedunits_gl4.lua
@@ -76,6 +76,7 @@ local GL_POINTS				= GL.POINTS
 local selUnits = {}
 local updateSelection = true
 local selectedUnits = spGetSelectedUnits()
+local drawCallinsEnabled = true
 
 local unitTeam = {}
 local unitUnitDefID = {}
@@ -101,6 +102,9 @@ for unitDefID, unitDef in pairs(UnitDefs) do
 	end
 end
 local unitBufferUniformCache = {0}
+local widgetDrawWorld = nil
+local widgetDrawWorldPreUnit = nil
+local UpdateDrawCallinsEnabled = nil
 
 local function getWaterLevel()
 	local lrs = WG.lavaRenderState
@@ -163,9 +167,6 @@ local function AddPrimitiveAtUnit(unitID)
 	if not buildingDims then
 		if Spring.GetUnitIsBeingBuilt(unitID) or unitDoneFrame[unitID] ~= nil then
 			useUnfinishedRenderPath = true
-			if not unitDoneFrame[unitID] then
-				unitDoneFrame[unitID] = 0
-			end
 			if not unitBuiltByFactory[unitID] then
 				useUnfinishedGeometry = true
 			end
@@ -276,20 +277,60 @@ local function DrawSelections(selectionVBO, shader)
 end
 
 if mapHasWater then
-	function widget:DrawWorld()
+	widgetDrawWorld = function()
 		-- Water-affected ground platters are drawn post-water to avoid refraction distortion.
 		DrawSelections(selectionVBOWater, waterShader)
 		DrawSelections(selectionVBOUnfinished, unbuiltShader)
 	end
 else
-	function widget:DrawWorld()
+	widgetDrawWorld = function()
 		DrawSelections(selectionVBOUnfinished, unbuiltShader)
 	end
 end
 
-function widget:DrawWorldPreUnit()
+widgetDrawWorldPreUnit = function()
 	-- Keep ground platters in pre-unit so units always overlap/occlude them.
 	DrawSelections(selectionVBOGround, false)
+end
+
+function widget:DrawWorld()
+	widgetDrawWorld()
+end
+
+function widget:DrawWorldPreUnit()
+	widgetDrawWorldPreUnit()
+end
+
+local function RefreshWidgetCallIn(name)
+	if not widgetHandler then
+		return
+	end
+	if widgetHandler.UpdateWidgetCallInRaw then
+		widgetHandler:UpdateWidgetCallInRaw(name, widget)
+	elseif widgetHandler.UpdateWidgetCallIn then
+		widgetHandler:UpdateWidgetCallIn(name, widget)
+	elseif widgetHandler.UpdateCallIn then
+		widgetHandler:UpdateCallIn(name)
+	end
+end
+
+UpdateDrawCallinsEnabled = function()
+	local shouldEnable = next(selUnits) ~= nil
+	if shouldEnable == drawCallinsEnabled then
+		return
+	end
+	drawCallinsEnabled = shouldEnable
+
+	if shouldEnable then
+		widget.DrawWorld = widgetDrawWorld
+		widget.DrawWorldPreUnit = widgetDrawWorldPreUnit
+	else
+		widget.DrawWorld = nil
+		widget.DrawWorldPreUnit = nil
+	end
+
+	RefreshWidgetCallIn("DrawWorld")
+	RefreshWidgetCallIn("DrawWorldPreUnit")
 end
 
 local function removeFromVBO(unitID, selectionVBO)
@@ -318,6 +359,9 @@ local function RemovePrimitive(unitID)
 		removeFromVBO(unitID, selectionVBOAir)
 	end
 	unitWaterPass[unitID] = nil
+	if UpdateDrawCallinsEnabled then
+		UpdateDrawCallinsEnabled()
+	end
 end
 
 function widget:SelectionChanged(sel)
@@ -330,6 +374,10 @@ local lastMouseOverFeatureID = nil
 local cleanedForHiddenUI = false
 local mouseOverUnitUniform = {0}
 local mouseOverFeatureUniform = {0}
+local lastMouseX, lastMouseY = -1, -1
+local lastMouseP1, lastMouseMMB = false, false
+local nextMouseOverCheckFrame = 0
+local mouseOverIdleCheckInterval = 4
 
 local function ClearLastMouseOver()
 	if lastMouseOverUnitID then
@@ -352,7 +400,6 @@ end
 
 function widget:Update(dt)
 	local guiHidden = spIsGUIHidden()
-	local gf = spGetGameFrame()
 	-- Handle UI visibility: clear selections when hidden, resync on show
 	if guiHidden then
 		if not cleanedForHiddenUI then
@@ -362,6 +409,7 @@ function widget:Update(dt)
 			end
 			-- Reset drawn selection state so we can rebuild when UI becomes visible
 			selUnits = {}
+			UpdateDrawCallinsEnabled()
 			cleanedForHiddenUI = true
 		end
 		-- Skip further processing while UI is hidden
@@ -390,25 +438,36 @@ function widget:Update(dt)
 		for unitID, _ in pairs(selUnits) do
 			if not newSelUnits[unitID] then
 				RemovePrimitive(unitID)
+				unitDoneFrame[unitID] = nil
 			end
 		end
 		selUnits = newSelUnits
+		UpdateDrawCallinsEnabled()
 	end
 
-	if mapHasWater and gf >= nextWaterPassCheckFrame then
-		nextWaterPassCheckFrame = gf + waterPassCheckInterval
-		local waterLevel = getWaterLevel()
-		-- Keep selected naval/submerged units in the post-water VBO as they move.
-		for unitID, _ in pairs(selUnits) do
-			local unitDefID = unitUnitDefID[unitID]
-			if unitDefID and not unitCanFly[unitDefID] then
-				local desiredWaterPass = shouldUseWaterPassAtLevel(unitID, unitDefID, waterLevel)
-				if desiredWaterPass ~= unitWaterPass[unitID] then
-					RemovePrimitive(unitID)
-					AddPrimitiveAtUnit(unitID)
+	local hasSelectedUnits = next(selUnits) ~= nil
+
+	if mapHasWater and hasSelectedUnits then
+		local gf = spGetGameFrame()
+		if gf >= nextWaterPassCheckFrame then
+			nextWaterPassCheckFrame = gf + waterPassCheckInterval
+			local waterLevel = getWaterLevel()
+			-- Keep selected naval/submerged units in the post-water VBO as they move.
+			for unitID, _ in pairs(selUnits) do
+				local unitDefID = unitUnitDefID[unitID]
+				if unitDefID and not unitCanFly[unitDefID] then
+					local desiredWaterPass = shouldUseWaterPassAtLevel(unitID, unitDefID, waterLevel)
+					if desiredWaterPass ~= unitWaterPass[unitID] then
+						RemovePrimitive(unitID)
+						AddPrimitiveAtUnit(unitID)
+					end
 				end
 			end
 		end
+	end
+
+	if not hasSelectedUnits and not mouseoverHighlight then
+		return
 	end
 
 	-- We move the check for mouseovered units here,
@@ -422,6 +481,23 @@ function widget:Update(dt)
 		if mouseOffScreen or cameraPanMode or mmb or p1 then
 			ClearLastMouseOver()
 		else
+			local shouldTraceMouse = true
+			if not hasSelectedUnits and not lastMouseOverUnitID and not lastMouseOverFeatureID then
+				local gf = spGetGameFrame()
+				if mx == lastMouseX and my == lastMouseY and p1 == lastMouseP1 and mmb == lastMouseMMB and gf < nextMouseOverCheckFrame then
+					shouldTraceMouse = false
+				else
+					nextMouseOverCheckFrame = gf + mouseOverIdleCheckInterval
+				end
+			end
+
+			lastMouseX, lastMouseY = mx, my
+			lastMouseP1, lastMouseMMB = p1, mmb
+
+			if not shouldTraceMouse then
+				return
+			end
+
 			local result, data = spTraceScreenRay(mx, my)
 			--spEcho(result, (type(data) == 'table') or data, lastMouseOverUnitID, lastMouseOverFeatureID)
 			if result == 'unit' and not guiHidden then
@@ -449,11 +525,13 @@ function widget:Update(dt)
 end
 
 function widget:GameFrame(frame)
+	if next(unitDoneFrame) == nil then
+		return
+	end
+
 	local swapFrame = frame - leaveFactoryFrames
 	for unitID, doneFrame in pairs(unitDoneFrame) do
-		if doneFrame == 0 then
-			-- continue
-		elseif doneFrame <= swapFrame then
+		if doneFrame <= swapFrame then
 			unitDoneFrame[unitID] = nil
 			if selUnits[unitID] then
 				RemovePrimitive(unitID)
@@ -475,9 +553,6 @@ function widget:UnitCreated(unitID, unitDefID, unitTeamID, builderID)
 		end
 	end
 
-	if Spring.GetUnitIsBeingBuilt(unitID) and not unitBuiltByFactory[unitID] then
-		unitDoneFrame[unitID] = unitDoneFrame[unitID] or 0
-	end
 end
 
 function widget:UnitFinished(unitID)
@@ -502,18 +577,20 @@ function widget:UnitDestroyed(unitID)
 	unitDoneFrame[unitID] = nil
 	unitWaterPass[unitID] = nil
 	unitBuiltByFactory[unitID] = nil
+	UpdateDrawCallinsEnabled()
 end
 
 local function init()
 	updateSelection = true
 	selUnits = {}
+	drawCallinsEnabled = true
 	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
 	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.BILLBOARD = 0
 	shaderConfig.TRANSPARENCY = opacity
 	shaderConfig.INITIALSIZE = 0.75
-	shaderConfig.GROWTHRATE = 3.5
+	shaderConfig.GROWTHRATE = 4		-- higher = slower
 	shaderConfig.TEAMCOLORIZATION = teamcolorOpacity	-- not implemented, doing it via POST_SHADING below instead
 	shaderConfig.HEIGHTOFFSET = 4
 	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(mix(g_color.rgb * texcolor.rgb + addRadius, vec3(1.0), "..(1-teamcolorOpacity)..") , texcolor.a * TRANSPARENCY + addRadius);"
@@ -545,6 +622,7 @@ local function init()
 		widgetHandler:RemoveWidget()
 		return false
 	end
+	UpdateDrawCallinsEnabled()
 	return true
 end
 

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -751,8 +751,10 @@ local function computeContent(uDefID, uID, shiftBool)
 
 		if custom.spark_forkdamage then
 			-- Sparks are hardcoded to target the default armor type:
-			local spDamage = custom.spark_basedamage * defaultArmorDamage
-			local spCount = custom.spark_maxunits
+			local spForkDamage = tonumber(custom.spark_forkdamage) or 0
+			local spBaseDamage = tonumber(custom.spark_basedamage) or 1
+			local spDamage = spBaseDamage * spForkDamage * defaultArmorDamage
+			local spCount = tonumber(custom.spark_maxunits) or 0
 			baseArmorDamage = baseArmorDamage + spDamage * spCount
 
 		elseif custom.speceffect == "split" then

--- a/luaui/Widgets/gui_unit_stats.lua
+++ b/luaui/Widgets/gui_unit_stats.lua
@@ -751,11 +751,10 @@ local function computeContent(uDefID, uID, shiftBool)
 
 		if custom.spark_forkdamage then
 			-- Sparks are hardcoded to target the default armor type:
+			local spDamage = defaultArmorDamage
 			local spForkDamage = tonumber(custom.spark_forkdamage) or 0
-			local spBaseDamage = tonumber(custom.spark_basedamage) or 1
-			local spDamage = spBaseDamage * spForkDamage * defaultArmorDamage
 			local spCount = tonumber(custom.spark_maxunits) or 0
-			baseArmorDamage = baseArmorDamage + spDamage * spCount
+			baseArmorDamage = baseArmorDamage + spDamage * spForkDamage * spCount
 
 		elseif custom.speceffect == "split" then
 			burst = burst * (custom.number or 1)

--- a/luaui/Widgets/map_startbox.lua
+++ b/luaui/Widgets/map_startbox.lua
@@ -189,9 +189,60 @@ end
 
 local teamColorComponents = {}
 local cachedTeamList = {}
+local teamInfoCache = {}
+local totalTeams = 0
+local aiManualPlacementCache = {}
+
+local function getCachedManualPlacement(teamID)
+	local raw = spGetTeamRulesParam(teamID, "aiManualPlacement")
+	local cached = aiManualPlacementCache[teamID]
+	if cached and cached.raw == raw then
+		return cached.x, cached.z, raw
+	end
+
+	local x, z
+	if raw then
+		local sx, sz = string.match(raw, "([%d%.]+),([%d%.]+)")
+		if sx and sz then
+			x = tonumber(sx)
+			z = tonumber(sz)
+		end
+	end
+
+	aiManualPlacementCache[teamID] = {raw = raw, x = x, z = z}
+	return x, z, raw
+end
 
 local function updateTeamList()
 	cachedTeamList = spGetTeamList()
+	totalTeams = 0
+
+	for teamID in pairs(teamInfoCache) do
+		teamInfoCache[teamID] = nil
+	end
+
+	for _, teamID in ipairs(cachedTeamList) do
+		if teamID ~= gaiaTeamID then
+			totalTeams = totalTeams + 1
+		end
+
+		local _, playerID, _, isAI, _, allyTeamID = spGetTeamInfo(teamID, false)
+		local playerName, isPlayerSpec
+		if playerID then
+			playerName, _, isPlayerSpec = spGetPlayerInfo(playerID, false)
+			if WG.playernames and WG.playernames.getPlayername then
+				playerName = WG.playernames.getPlayername(playerID) or playerName
+			end
+		end
+
+		teamInfoCache[teamID] = {
+			playerID = playerID,
+			isAI = isAI,
+			allyTeamID = allyTeamID,
+			isPlayerSpec = isPlayerSpec,
+			playerName = playerName,
+		}
+	end
 end
 
 local function assignTeamColors()
@@ -350,8 +401,14 @@ local function shouldRenderTeam(teamID, excludeMyTeam)
 		return false
 	end
 
-	local _, playerID, _, isAI, _, teamAllyTeamID = spGetTeamInfo(teamID, false)
-	local _, _, spec = spGetPlayerInfo(playerID, false)
+	local teamInfo = teamInfoCache[teamID]
+	if not teamInfo then
+		return false
+	end
+
+	local isAI = teamInfo.isAI
+	local teamAllyTeamID = teamInfo.allyTeamID
+	local spec = teamInfo.isPlayerSpec
 
 	local x, y, z = getEffectiveStartPosition(teamID)
 
@@ -574,13 +631,55 @@ local function DrawStartCones(inminimap)
 	startConeShader:Deactivate()
 end
 
-local cacheTable = {}
-local circlesToDraw = {}
-local function getCircleEntry(index)
-	if not circlesToDraw[index] then
-		circlesToDraw[index] = {0, 0, 0}
-	end
-	return circlesToDraw[index]
+local iconEntries = {}
+local iconEntriesCount = 0
+local function compareIconEntryByTexture(a, b)
+	return a.texPath < b.texPath
+end
+
+local borderX1, borderY1, borderX2, borderY2, borderChamferShared
+local function drawBorderPolygon()
+	glVertex(borderX1 + borderChamferShared, borderY1)
+	glVertex(borderX2 - borderChamferShared, borderY1)
+	glVertex(borderX2, borderY1 + borderChamferShared)
+	glVertex(borderX2, borderY2 - borderChamferShared)
+	glVertex(borderX2 - borderChamferShared, borderY2)
+	glVertex(borderX1 + borderChamferShared, borderY2)
+	glVertex(borderX1, borderY2 - borderChamferShared)
+	glVertex(borderX1, borderY1 + borderChamferShared)
+end
+
+local fillX1, fillY1, fillX2, fillY2, fillChamferShared
+local function drawFillPolygon()
+	glVertex(fillX1 + fillChamferShared, fillY1)
+	glVertex(fillX2 - fillChamferShared, fillY1)
+	glVertex(fillX2, fillY1 + fillChamferShared)
+	glVertex(fillX2, fillY2 - fillChamferShared)
+	glVertex(fillX2 - fillChamferShared, fillY2)
+	glVertex(fillX1 + fillChamferShared, fillY2)
+	glVertex(fillX1, fillY2 - fillChamferShared)
+	glVertex(fillX1, fillY1 + fillChamferShared)
+end
+
+local iconX1, iconY1, iconX2, iconY2
+local iconChamferShared, texZoomShared, texChamferShared
+local function drawIconPolygon()
+	glTexCoord(texZoomShared + texChamferShared, 1 - texZoomShared)
+	glVertex(iconX1 + iconChamferShared, iconY1)
+	glTexCoord(1 - texZoomShared - texChamferShared, 1 - texZoomShared)
+	glVertex(iconX2 - iconChamferShared, iconY1)
+	glTexCoord(1 - texZoomShared, 1 - texZoomShared - texChamferShared)
+	glVertex(iconX2, iconY1 + iconChamferShared)
+	glTexCoord(1 - texZoomShared, texZoomShared + texChamferShared)
+	glVertex(iconX2, iconY2 - iconChamferShared)
+	glTexCoord(1 - texZoomShared - texChamferShared, texZoomShared)
+	glVertex(iconX2 - iconChamferShared, iconY2)
+	glTexCoord(texZoomShared + texChamferShared, texZoomShared)
+	glVertex(iconX1 + iconChamferShared, iconY2)
+	glTexCoord(texZoomShared, texZoomShared + texChamferShared)
+	glVertex(iconX1, iconY2 - iconChamferShared)
+	glTexCoord(texZoomShared, 1 - texZoomShared - texChamferShared)
+	glVertex(iconX1, iconY1 + iconChamferShared)
 end
 
 local teamsToRender = {}
@@ -591,6 +690,7 @@ local function updateTeamsToRender()
 	for _, teamID in ipairs(cachedTeamList) do
 		local shouldRender, x, y, z, isAI = shouldRenderTeam(teamID, false)
 		if shouldRender then
+			local teamInfo = teamInfoCache[teamID]
 			teamsToRenderCount = teamsToRenderCount + 1
 			local entry = teamsToRender[teamsToRenderCount]
 			if not entry then
@@ -602,6 +702,7 @@ local function updateTeamsToRender()
 			entry.y = y
 			entry.z = z
 			entry.isAI = isAI
+			entry.displayName = isAI and getAIName(teamID, true) or (teamInfo and teamInfo.playerName)
 		end
 	end
 end
@@ -623,7 +724,6 @@ local function getStartUnitTexture(teamID)
 	return 'unitpics/other/dice.dds'
 end
 
-local totalTeams = #Spring.GetTeamList()-1
 local function buildIconList(sx, sz)
 	-- Ensure teams data is populated (DrawInMiniMap may be called before DrawWorld)
 	if not teamsToRenderCount or teamsToRenderCount == 0 then
@@ -655,9 +755,9 @@ local function buildIconList(sx, sz)
 	local texChamfer = (iconChamfer / iconSize2) * (1 - 2 * texZoom)
 
 	-- Pre-compute all icon data and sort by texture to minimize state changes
-	local entries = {}
+	local entries = iconEntries
 	local entryCount = 0
-	for i = 1, (teamsToRenderCount or 0) do
+	for i = 1, teamsToRenderCount do
 		local entry = teamsToRender[i]
 		local teamID = entry.teamID
 		local worldX, worldZ = entry.x, entry.z
@@ -684,12 +784,29 @@ local function buildIconList(sx, sz)
 			drawY = math.floor(drawY + 0.5)
 			local r, g, b = GetTeamColor(teamID)
 			entryCount = entryCount + 1
-			entries[entryCount] = { drawX = drawX, drawY = drawY, r = r, g = g, b = b, texPath = texPath }
+			local iconEntry = entries[entryCount]
+			if not iconEntry then
+				iconEntry = {}
+				entries[entryCount] = iconEntry
+			end
+			iconEntry.drawX = drawX
+			iconEntry.drawY = drawY
+			iconEntry.r = r
+			iconEntry.g = g
+			iconEntry.b = b
+			iconEntry.texPath = texPath
 		end
 	end
 
+	if iconEntriesCount > entryCount then
+		for i = entryCount + 1, iconEntriesCount do
+			entries[i] = nil
+		end
+	end
+	iconEntriesCount = entryCount
+
 	-- Sort by texture path to batch texture state changes
-	table.sort(entries, function(a, b) return a.texPath < b.texPath end)
+	table.sort(entries, compareIconEntryByTexture)
 
 	return gl.CreateList(function()
 		-- Draw all borders + team-color backgrounds first (no texture needed)
@@ -702,32 +819,21 @@ local function buildIconList(sx, sz)
 			local bx2, by2 = x2 + borderSize, y2 + borderSize
 
 			glColor(0, 0, 0, 0.25)
-			glBeginEnd(GL_POLYGON, function()
-				glVertex(bx1 + borderChamfer, by1)
-				glVertex(bx2 - borderChamfer, by1)
-				glVertex(bx2, by1 + borderChamfer)
-				glVertex(bx2, by2 - borderChamfer)
-				glVertex(bx2 - borderChamfer, by2)
-				glVertex(bx1 + borderChamfer, by2)
-				glVertex(bx1, by2 - borderChamfer)
-				glVertex(bx1, by1 + borderChamfer)
-			end)
+			borderX1, borderY1, borderX2, borderY2 = bx1, by1, bx2, by2
+			borderChamferShared = borderChamfer
+			glBeginEnd(GL_POLYGON, drawBorderPolygon)
 
 			glColor(e.r, e.g, e.b, 0.7)
-			glBeginEnd(GL_POLYGON, function()
-				glVertex(x1 + chamfer, y1)
-				glVertex(x2 - chamfer, y1)
-				glVertex(x2, y1 + chamfer)
-				glVertex(x2, y2 - chamfer)
-				glVertex(x2 - chamfer, y2)
-				glVertex(x1 + chamfer, y2)
-				glVertex(x1, y2 - chamfer)
-				glVertex(x1, y1 + chamfer)
-			end)
+			fillX1, fillY1, fillX2, fillY2 = x1, y1, x2, y2
+			fillChamferShared = chamfer
+			glBeginEnd(GL_POLYGON, drawFillPolygon)
 		end
 
 		-- Draw all textured icons (sorted by texture to minimize state changes)
 		glColor(1, 1, 1, 1)
+		iconChamferShared = iconChamfer
+		texZoomShared = texZoom
+		texChamferShared = texChamfer
 		local prevTex = nil
 		for i = 1, entryCount do
 			local e = entries[i]
@@ -735,26 +841,9 @@ local function buildIconList(sx, sz)
 				glTexture(e.texPath)
 				prevTex = e.texPath
 			end
-			local ix1, iy1 = e.drawX - iconHalf, e.drawY - iconHalf
-			local ix2, iy2 = e.drawX + iconHalf, e.drawY + iconHalf
-			glBeginEnd(GL_POLYGON, function()
-				glTexCoord(texZoom + texChamfer, 1 - texZoom)
-				glVertex(ix1 + iconChamfer, iy1)
-				glTexCoord(1 - texZoom - texChamfer, 1 - texZoom)
-				glVertex(ix2 - iconChamfer, iy1)
-				glTexCoord(1 - texZoom, 1 - texZoom - texChamfer)
-				glVertex(ix2, iy1 + iconChamfer)
-				glTexCoord(1 - texZoom, texZoom + texChamfer)
-				glVertex(ix2, iy2 - iconChamfer)
-				glTexCoord(1 - texZoom - texChamfer, texZoom)
-				glVertex(ix2 - iconChamfer, iy2)
-				glTexCoord(texZoom + texChamfer, texZoom)
-				glVertex(ix1 + iconChamfer, iy2)
-				glTexCoord(texZoom, texZoom + texChamfer)
-				glVertex(ix1, iy2 - iconChamfer)
-				glTexCoord(texZoom, 1 - texZoom - texChamfer)
-				glVertex(ix1, iy1 + iconChamfer)
-			end)
+			iconX1, iconY1 = e.drawX - iconHalf, e.drawY - iconHalf
+			iconX2, iconY2 = e.drawX + iconHalf, e.drawY + iconHalf
+			glBeginEnd(GL_POLYGON, drawIconPolygon)
 		end
 		glTexture(false)
 	end)
@@ -984,13 +1073,12 @@ function widget:Initialize()
 			local _, _, _, isAI, _, _ = spGetTeamInfo(teamID, false)
 			if isAI then
 				local startX, _, startZ = spGetTeamStartPosition(teamID)
-				local aiManualPlacement = spGetTeamRulesParam(teamID, "aiManualPlacement")
+				local mxNum, mzNum, aiManualPlacement = getCachedManualPlacement(teamID)
 
 				if (startX and startZ and startX > 0 and startZ > 0) or aiManualPlacement then
 					if aiManualPlacement then
-						local mx, mz = string.match(aiManualPlacement, "([%d%.]+),([%d%.]+)")
-						if mx and mz then
-							startX, startZ = tonumber(mx), tonumber(mz)
+						if mxNum and mzNum then
+							startX, startZ = mxNum, mzNum
 						end
 					end
 
@@ -1045,27 +1133,28 @@ function widget:DrawWorldPreUnit()
 	DrawStartPolygons(false)
 end
 
-local cacheTable = {}
-local circlesToDraw = {}
-local function getCircleEntry(index)
-	if not circlesToDraw[index] then
-		circlesToDraw[index] = {0, 0, 0}
-	end
-	return circlesToDraw[index]
-end
+local drawStartCones = false
+local coneInstanceData = {}
 
 function widget:DrawWorld()
 	clearPosCache()
 	updateTeamsToRender() -- Calculate visibility once per frame
+	if teamsToRenderCount == 0 then
+		return
+	end
 
 	gl.Blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+	gl.Color(1.0, 0.0, 0.0, 0.3)
 
-	local time = Spring.DiffTimers(Spring.GetTimer(), startTimer)
-	local alpha = 0.5 + mathAbs(((time * 3) % 1) - 0.5)
+	if drawStartCones then
+		InstanceVBOTable.clearInstanceTable(startConeVBOTable)
+	end
 
-	InstanceVBOTable.clearInstanceTable(startConeVBOTable)
-
-	local cCount = 0
+	local time, alpha
+	if drawStartCones then
+		time = Spring.DiffTimers(Spring.GetTimer(), startTimer)
+		alpha = 0.5 + mathAbs(((time * 3) % 1) - 0.5)
+	end
 
 	for i = 1, teamsToRenderCount do
 		local entry = teamsToRender[i]
@@ -1073,53 +1162,45 @@ function widget:DrawWorld()
 		local x, y, z = entry.x, entry.y, entry.z
 		local isAI = entry.isAI
 
-		local r, g, b = GetTeamColor(teamID)
+		if drawStartCones then
+			local color = teamColorComponents[teamID]
+			if color then
+				coneInstanceData[1], coneInstanceData[2], coneInstanceData[3], coneInstanceData[4] = x, y, z, 1
+				coneInstanceData[5], coneInstanceData[6], coneInstanceData[7], coneInstanceData[8] = color[1], color[2], color[3], alpha
+				pushElementInstance(startConeVBOTable, coneInstanceData, nil, nil, true)
+			end
+		end
 
-		cacheTable[1], cacheTable[2], cacheTable[3], cacheTable[4] = x, y, z, 1
-		cacheTable[5], cacheTable[6], cacheTable[7], cacheTable[8] = r, g, b, alpha
-		pushElementInstance(startConeVBOTable,
-			cacheTable,
-			nil, nil, true)
 		if teamID == myTeamID then
 			amPlaced = true
 		end
 
 		if teamID ~= myTeamID and (not isAI or aiPlacedPositions[teamID]) then
-			cCount = cCount + 1
-			local circleEntry = getCircleEntry(cCount)
-			circleEntry[1], circleEntry[2], circleEntry[3] = x, y, z
+			glDrawGroundCircle(x, y, z, tooCloseToSpawn, 32)
 		end
 	end
 
-	InstanceVBOTable.uploadAllElements(startConeVBOTable)
-
-	--DrawStartCones(false)
-
-	if cCount > 0 then
-		gl.Color(1.0, 0.0, 0.0, 0.3)
-		for i = 1, cCount do
-			local p = circlesToDraw[i]
-			glDrawGroundCircle(p[1], p[2], p[3], tooCloseToSpawn, 32)
-		end
+	if drawStartCones then
+		InstanceVBOTable.uploadAllElements(startConeVBOTable)
+		DrawStartCones(false)
 	end
 end
 
 function widget:DrawScreenEffects()
+	if teamsToRenderCount == 0 then
+		clearPosCache()
+		updateTeamsToRender()
+		if teamsToRenderCount == 0 then
+			return
+		end
+	end
+
 	-- show the names over the team start positions
 	for i = 1, teamsToRenderCount do
 		local entry = teamsToRender[i]
 		local teamID = entry.teamID
 		local x, y, z = entry.x, entry.y, entry.z
-		local isAI = entry.isAI
-
-		local _, playerID = spGetTeamInfo(teamID, false)
-		local name = spGetPlayerInfo(playerID, false)
-
-		if isAI then
-			name = getAIName(teamID, true)
-		else
-			name = WG.playernames and WG.playernames.getPlayername(playerID) or name
-		end
+		local name = entry.displayName
 
 		if name then
 			local sx, sy, sz = Spring.WorldToScreenCoords(x, y + 120, z)
@@ -1244,11 +1325,9 @@ function widget:Update(delta)
 							end
 							aiPlacementStatus[teamID] = true
 						else
-							local aiManualPlacement = spGetTeamRulesParam(teamID, "aiManualPlacement")
+							local mxNum, mzNum, aiManualPlacement = getCachedManualPlacement(teamID)
 							if aiManualPlacement then
-								local mx, mz = string.match(aiManualPlacement, "([%d%.]+),([%d%.]+)")
-								if mx and mz then
-									local mxNum, mzNum = tonumber(mx), tonumber(mz)
+								if mxNum and mzNum then
 									local existing = aiPlacedPositions[teamID]
 									if existing then
 										if existing.x ~= mxNum or existing.z ~= mzNum then

--- a/modelmaterials_gl4/templates/cus_gl4.frag.glsl
+++ b/modelmaterials_gl4/templates/cus_gl4.frag.glsl
@@ -921,8 +921,11 @@ void main(void){
 	// while it burns, so healthFraction goes 1 -> ~0. A full-health tree has
 	// charAmount 0 and is completely unaffected. As it chars, the bark darkens
 	// toward near-black charcoal. Charred wood is also forced matte/non-metallic.
+	// Suppress char during pregame (simFrame ~ 0) so map trees that spawn with
+	// pathological health values do not appear burnt before the match starts.
 	{
 		float charAmount = clamp(1.0 - aoterm_fogFactor_selfIllumMod_healthFraction.w, 0.0, 1.0);
+		charAmount *= step(0.5, simFrame);
 		if (charAmount > 0.002) {
 			albedoColor = mix(albedoColor, vec3(0.018, 0.015, 0.013), charAmount);
 			roughness = max(roughness, mix(roughness, 0.9, charAmount));

--- a/units/Scavengers/Vehicles/corves.lua
+++ b/units/Scavengers/Vehicles/corves.lua
@@ -247,14 +247,14 @@ return {
 			[2] = {
 				badtargetcategory = "VTOL",
 				def = "banisher",
-				onlytargetcategory = "SURFACE",
+				onlytargetcategory = "NOTSUB",
 				maindir = "-1 0 0",
 				maxangledif = 180,
 			},
 			[3] = {
 				badtargetcategory = "VTOL",
 				def = "banisher",
-				onlytargetcategory = "SURFACE",
+				onlytargetcategory = "NOTSUB",
 				maindir = "1 0 0",
 				maxangledif = 180,
 			},


### PR DESCRIPTION
First chunk of the team-transfer split. The evaluation pipeline that decides **whether** a team-to-team transfer is allowed and **how much** actually moves. Four stages, mirrored for resources and units:

| Stage | Resource | Unit |
|---|---|---|
| **context** | `context_factory.lua` builds a `PolicyContext` per pair (resource snapshot + live gates: allied, cheating) | same |
| **policy** | `CalcResourcePolicy` — deny gates, tax rate, `taxedSendable`/`capacity` | `GetPolicy` — allied + sharing modes + share-time effects |
| **policy_result** | `CombineResourcePolicy` (`*_shared.lua` owns shape + pure math) | `UnitPolicyResult` + `ValidateUnits` |
| **action** | `ResourceTransfer` — capped, taxed, `Set/AddTeamResource` | `UnitTransfer` — `TransferUnit` per valid id |

Each action is a no-op when `canShare` is false.

**Scope:** the pipeline only (~994 lines, 6 files). The cached read-path mirror, policy events, comms/serialization, tech-blocking enrichers, and GUI packing land in later chunks — the `VFS.Include`s referencing them resolve there, so this branch is a reviewable unit rather than an independently loadable one.