### PR TITLE
campaign api: hello pawn

### DIFF
--- a/.busted
+++ b/.busted
@@ -12,7 +12,8 @@ return {
       "luarules/?.lua", "luarules/?/init.lua",
       "luaui/?.lua", "luaui/?/init.lua",
       "spec/?.lua", "spec/?/init.lua",
-    }, ";")
+    }, ";"),
+    helper = "spec/spec_helper.lua",
   },
   -- Default configuration
   verbose = true,

--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -61,7 +61,12 @@
       "CMD_WANTED_SPEED",
       "GadgetCrashingAircraft",
       "ExplosionDefs",
-      "GL_TEXTURE_2D"
+      "GL_TEXTURE_2D",
+      "T",
+      "Team",
+      "UnitDef",
+      "Objective",
+      "MatchFlow"
     ]
   },
   "runtime": {

--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -66,7 +66,13 @@
       "Team",
       "UnitDef",
       "Objective",
-      "MatchFlow"
+      "MatchFlow",
+      "describe",
+      "it",
+      "before_each",
+      "after_each",
+      "setup",
+      "teardown"
     ]
   },
   "runtime": {

--- a/luarules/gadgets.lua
+++ b/luarules/gadgets.lua
@@ -510,6 +510,17 @@ function gadgetHandler:Initialize()
 	local gadgetFiles = VFS.DirList(GADGETS_DIR, "*.lua", VFSMODE)
 	--  table.sort(gadgetFiles)
 
+	-- Encapsulated modules ship their own gadgets (modules/<name>/gadgets/).
+	-- Game-side shim until the engine loads module subdirectories natively.
+	if Script.GetName():gsub("US$", "") == "LuaRules" then
+		local ModuleHandler = VFS.Include("modules/module_handler.lua", nil, VFSMODE)
+		for _, moduleGadgetDir in ipairs(ModuleHandler.GadgetDirs(VFSMODE)) do
+			for _, gf in ipairs(VFS.DirList(moduleGadgetDir, "*.lua", VFSMODE)) do
+				gadgetFiles[#gadgetFiles + 1] = gf
+			end
+		end
+	end
+
 	--  for k,gf in ipairs(gadgetFiles) do
 	--    Spring.Echo('gf1 = ' .. gf) -- FIXME
 	--  end

--- a/luaui/Tests/hello_pawns/test_win.lua
+++ b/luaui/Tests/hello_pawns/test_win.lua
@@ -41,18 +41,38 @@ function test()
 	-- Buffer GameOver before anything can win.
 	Test.expectCallin("GameOver")
 
-	-- Cheat-spawn toward the objective instead of really building (the trigger
-	-- counts finished units either way).
+	-- Cheat-spawn toward the objective instead of really building: two finished
+	-- Pawns plus one nanoframe. Has() means COMPLETED units — the nanoframe
+	-- must not win the mission (the factory-blueprint bug).
 	local x = Game.mapSizeX / 2
 	local z = Game.mapSizeZ / 2
-	SyncedRun(function(locals)
-		for i = 1, locals.pawnCount do
+	local frameUnitID = SyncedRun(function(locals)
+		for i = 1, locals.pawnCount - 1 do
 			Spring.CreateUnit(locals.pawnName, locals.x + i * 32, Spring.GetGroundHeight(locals.x + i * 32, locals.z), locals.z, 0, locals.teamID)
 		end
+		-- The nanoframe needs a live builder: unit_prevent_lab_hax2 destroys
+		-- fresh under-construction units whose builder is dead/absent.
+		local builderID = Spring.CreateUnit("armck", locals.x - 64, Spring.GetGroundHeight(locals.x - 64, locals.z), locals.z, 0, locals.teamID)
+		local unitID = Spring.CreateUnit(locals.pawnName, locals.x, Spring.GetGroundHeight(locals.x, locals.z), locals.z, 0, locals.teamID, true, true, nil, builderID)
+		if unitID ~= nil then
+			-- Give it real progress so abandoned-nanoframe decay stays far away.
+			Spring.SetUnitHealth(unitID, { build = 0.8 })
+		end
+		return unitID
 	end)
+	assert(frameUnitID ~= nil, "failed to spawn the nanoframe Pawn")
 
 	Test.waitUntil(function()
 		return Spring.GetTeamUnitDefCount(teamID, pawnDefID) >= PAWN_COUNT
+	end)
+
+	-- Two evaluation cadences with the third Pawn still a nanoframe: no verdict.
+	Test.waitFrames(2 * 15 + 2)
+	assert(Spring.GetGameRulesParam("objective_build_pawns") ~= 1, "mission must not complete while the third Pawn is a nanoframe")
+
+	-- Finish the build; NOW the mission should be won.
+	SyncedRun(function(locals)
+		Spring.SetUnitHealth(locals.frameUnitID, { build = 1 })
 	end)
 
 	-- The mission's effect chain: objective completes, then scripted victory

--- a/luaui/Tests/hello_pawns/test_win.lua
+++ b/luaui/Tests/hello_pawns/test_win.lua
@@ -1,0 +1,73 @@
+---@diagnostic disable: lowercase-global, undefined-field
+
+-- Plays the hello_pawns mission end to end: load it via the chat command,
+-- reach 3 Pawns, expect scripted victory through the matchflow verdict path.
+-- Fails if DSL registration breaks, the loader env is missing a verb, the
+-- condition never fires, or the verdict path is disconnected.
+--
+-- NOTE: this test really ends the game (Spring.GameOver). If it disturbs
+-- later tests in a full suite run, scope the run: `runtestsheadless hello_pawns`.
+
+local PAWN = "armpw"
+local PAWN_COUNT = 3
+
+function skip()
+	return Spring.GetGameFrame() <= 0
+end
+
+function setup()
+	Test.clearMap()
+end
+
+function cleanup()
+	Test.clearMap()
+end
+
+function test()
+	-- SyncedRun ships the caller's stack locals (not upvalues), so copy the
+	-- file-level config into locals for the spawn block below.
+	local pawnName = PAWN
+	local pawnCount = PAWN_COUNT
+	local teamID = Spring.GetLocalTeamID()
+	local _, _, _, _, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+	local pawnDefID = UnitDefNames[PAWN].id
+
+	-- Arm the mission via the same chat command a player would use.
+	Spring.SendCommands("luarules mission hello_pawns")
+	Test.waitUntil(function()
+		return Spring.GetGameRulesParam("mission_active") == 1
+	end)
+
+	-- Buffer GameOver before anything can win.
+	Test.expectCallin("GameOver")
+
+	-- Cheat-spawn toward the objective instead of really building (the trigger
+	-- counts finished units either way).
+	local x = Game.mapSizeX / 2
+	local z = Game.mapSizeZ / 2
+	SyncedRun(function(locals)
+		for i = 1, locals.pawnCount do
+			Spring.CreateUnit(locals.pawnName, locals.x + i * 32, Spring.GetGroundHeight(locals.x + i * 32, locals.z), locals.z, 0, locals.teamID)
+		end
+	end)
+
+	Test.waitUntil(function()
+		return Spring.GetTeamUnitDefCount(teamID, pawnDefID) >= PAWN_COUNT
+	end)
+
+	-- The mission's effect chain: objective completes, then scripted victory
+	-- for the player's ally team.
+	Test.waitUntilCallin("GameOver", function(winningAllyTeams)
+		if type(winningAllyTeams) ~= "table" then
+			return false
+		end
+		for _, winner in ipairs(winningAllyTeams) do
+			if winner == allyTeamID then
+				return true
+			end
+		end
+		return false
+	end, 10 * 30)
+
+	assert(Spring.GetGameRulesParam("objective_build_pawns") == 1, "objective build_pawns should be complete before victory")
+end

--- a/luaui/Widgets/dbg_test_runner.lua
+++ b/luaui/Widgets/dbg_test_runner.lua
@@ -1047,6 +1047,9 @@ local function initializeTestEnvironment()
 		type = type,
 		unpack = unpack,
 		select = select,
+		setmetatable = setmetatable,
+		getmetatable = getmetatable,
+		getfenv = getfenv,
 		Scenario = scenarioConfig,
 
 		Json = Json,

--- a/modules/matchflow/api.lua
+++ b/modules/matchflow/api.lua
@@ -1,0 +1,30 @@
+--- Synced contract of the matchflow module — DEMO-MINIMAL: the scripted-verdict
+--- path only, not the game_end extraction (that is matchflow_module_plan.md,
+--- later). The point of this file is the call shape: `MatchFlow.Victory(...)`
+--- survives unchanged when the real module lands underneath it.
+---
+--- The pending verdict lives in the verdict gadget (one owner); contract
+--- includes are per-consumer, so this file holds no state and forwards
+--- through the gadget's GG surface.
+
+---@param name string
+---@return table
+local function gadgetSurface(name)
+	local surface = GG.MatchFlow
+	assert(surface ~= nil, "MatchFlow." .. name .. " called before the matchflow_verdict gadget initialized")
+	return surface
+end
+
+return {
+	---Scripted victory: the given ally team wins on the next verdict tick.
+	---@param allyTeamID integer
+	Victory = function(allyTeamID)
+		gadgetSurface("Victory").Victory(allyTeamID)
+	end,
+
+	---Scripted defeat: every other ally team (bar Gaia) wins.
+	---@param allyTeamIDs integer[]
+	Defeat = function(allyTeamIDs)
+		gadgetSurface("Defeat").Defeat(allyTeamIDs)
+	end,
+}

--- a/modules/matchflow/gadgets/matchflow_verdict.lua
+++ b/modules/matchflow/gadgets/matchflow_verdict.lua
@@ -1,0 +1,64 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "MatchFlow Verdict",
+		desc = "Scripted-verdict path of the matchflow module: applies pending Victory/Defeat verdicts (demo-minimal; the game_end extraction comes later)",
+		author = "Beyond All Reason",
+		date = "July 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+-- DEMO-ONLY coexistence: game_end.lua still runs its own end conditions, the
+-- same way missions coexist with it today (the scenariooptions path). This
+-- gadget only ever ends the game when a mission scripted a verdict.
+
+---@type integer[]|nil winning ally team ids; applied on the next GameFrame
+local pendingWinners = nil
+
+---@param allyTeamID integer
+local function Victory(allyTeamID)
+	pendingWinners = { allyTeamID }
+end
+
+---@param losers integer[]
+local function Defeat(losers)
+	local losing = {}
+	for _, allyTeamID in ipairs(losers) do
+		losing[allyTeamID] = true
+	end
+	local gaiaAllyTeam = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
+	local winners = {}
+	for _, allyTeamID in ipairs(Spring.GetAllyTeamList()) do
+		if not losing[allyTeamID] and allyTeamID ~= gaiaAllyTeam then
+			winners[#winners + 1] = allyTeamID
+		end
+	end
+	pendingWinners = winners
+end
+
+function gadget:Initialize()
+	GG.MatchFlow = {
+		Victory = Victory,
+		Defeat = Defeat,
+	}
+end
+
+function gadget:Shutdown()
+	GG.MatchFlow = nil
+end
+
+function gadget:GameFrame()
+	if pendingWinners ~= nil then
+		local winners = pendingWinners
+		pendingWinners = nil
+		Spring.GameOver(winners)
+	end
+end

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -1,0 +1,151 @@
+local gadget = gadget ---@type Gadget
+
+function gadget:GetInfo()
+	return {
+		name = "Mission Loader",
+		desc = "Loads mission trigger files (/luarules mission <name>) into the trigger engine and evaluates them on a cadence",
+		author = "Beyond All Reason",
+		date = "July 2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = true,
+	}
+end
+
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+local LOG_TAG = "mission_loader"
+
+local ModuleHandler = VFS.Include("modules/module_handler.lua")
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local MISSIONS_DIR = "modules/missions/"
+local EVALUATE_PERIOD = 15 -- frames
+
+local engine = TriggerEngine.New()
+local activeMission = nil ---@type string|nil
+
+--- The engine's view of the world. Built once; frame is updated per tick.
+---@type MissionContext
+local ctx = {
+	frame = 0,
+	GetUnitDefCount = function(teamID, unitDefName)
+		local unitDef = UnitDefNames[unitDefName]
+		if unitDef == nil then
+			return 0
+		end
+		return Spring.GetTeamUnitDefCount(teamID, unitDef.id)
+	end,
+}
+
+---Demo rule (documented in hello_pawns_plan.md): Team.Player is the first
+---human team — lowest non-Gaia teamID with no Lua AI and not the AI-hosted kind.
+---@return MissionTeam|nil
+local function resolvePlayerTeam()
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+	for _, teamID in ipairs(Spring.GetTeamList()) do
+		if teamID ~= gaiaTeamID then
+			local _, _, _, isAiTeam, _, allyTeamID = Spring.GetTeamInfo(teamID, false)
+			if not isAiTeam and (Spring.GetTeamLuaAI(teamID) or "") == "" then
+				return Verbs.MakeTeam(teamID, allyTeamID)
+			end
+		end
+	end
+	return nil
+end
+
+---Objective verb, demo-minimal: Complete() echoes and flips a rulesparam
+---(objective_<name>) that UI or tests can read. No objective widget tonight.
+---@param name string
+---@return { Complete: fun() }
+local function Objective(name)
+	return {
+		Complete = function()
+			Spring.SetGameRulesParam("objective_" .. name, 1)
+			Spring.Echo("[" .. LOG_TAG .. "] objective complete: " .. name)
+		end,
+	}
+end
+
+---Load (or reload) a mission: run each triggers/*.lua through the injected
+---environment. The sandbox IS the API surface — trigger files see the five
+---verbs and nothing else. Unregister-by-identity first makes loading
+---idempotent and is the hot-reload path.
+---@param missionName string
+---@return boolean loaded
+local function loadMission(missionName)
+	local triggersDir = MISSIONS_DIR .. missionName .. "/triggers/"
+	local files = VFS.DirList(triggersDir, "*.lua")
+	if #files == 0 then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no trigger files under " .. triggersDir)
+		return false
+	end
+	table.sort(files)
+
+	local playerTeam = resolvePlayerTeam()
+	if playerTeam == nil then
+		Spring.Log(LOG_TAG, LOG.ERROR, "no human team found for Team.Player")
+		return false
+	end
+
+	local matchFlow = ModuleHandler.Get("matchflow")
+
+	for _, filePath in ipairs(files) do
+		-- Identity is mission-relative so ids survive install-path differences.
+		local filename = filePath:sub(#MISSIONS_DIR + 1)
+		engine.UnregisterFile(filename)
+		local env = {
+			T = DSL.ForFile(filename, engine.Register),
+			Team = { Player = playerTeam },
+			UnitDef = Verbs.UnitDef,
+			Objective = Objective,
+			MatchFlow = matchFlow,
+		}
+		VFS.Include(filePath, env)
+	end
+
+	activeMission = missionName
+	Spring.SetGameRulesParam("mission_active", 1)
+	Spring.Echo("[" .. LOG_TAG .. "] mission armed: " .. missionName .. " (" .. #engine.Triggers() .. " trigger(s))")
+	return true
+end
+
+---@param cmd string
+---@param line string
+---@param words string[]
+local function missionChatAction(cmd, line, words)
+	local missionName = words[1]
+	if missionName == nil or missionName == "" then
+		Spring.Log(LOG_TAG, LOG.ERROR, "usage: /luarules mission <name> | reload")
+		return true
+	end
+	if missionName == "reload" then
+		if activeMission == nil then
+			Spring.Log(LOG_TAG, LOG.ERROR, "no active mission to reload")
+			return true
+		end
+		missionName = activeMission
+	end
+	loadMission(missionName)
+	return true
+end
+
+function gadget:Initialize()
+	gadgetHandler:AddChatAction("mission", missionChatAction, "load a mission: /luarules mission <name>")
+end
+
+function gadget:Shutdown()
+	gadgetHandler:RemoveChatAction("mission")
+end
+
+---@param frame integer
+function gadget:GameFrame(frame)
+	if activeMission ~= nil and frame % EVALUATE_PERIOD == 0 then
+		ctx.frame = frame
+		engine.Evaluate(ctx)
+	end
+end

--- a/modules/missions/gadgets/mission_loader.lua
+++ b/modules/missions/gadgets/mission_loader.lua
@@ -38,7 +38,15 @@ local ctx = {
 		if unitDef == nil then
 			return 0
 		end
-		return Spring.GetTeamUnitDefCount(teamID, unitDef.id)
+		-- GetTeamUnitDefCount includes nanoframes; Has() means finished units,
+		-- so filter out anything still being built.
+		local count = 0
+		for _, unitID in ipairs(Spring.GetTeamUnitsByDefs(teamID, unitDef.id)) do
+			if not Spring.GetUnitIsBeingBuilt(unitID) then
+				count = count + 1
+			end
+		end
+		return count
 	end,
 }
 

--- a/modules/missions/hello_pawns/triggers/win.lua
+++ b/modules/missions/hello_pawns/triggers/win.lua
@@ -1,0 +1,6 @@
+T.When(Team.Player.Has(UnitDef("armpw"), 3))
+	.Then(function()
+		Objective("build_pawns").Complete()
+		MatchFlow.Victory(Team.Player.allyTeam)
+	end)
+	.Register()

--- a/modules/missions/lib/dsl.lua
+++ b/modules/missions/lib/dsl.lua
@@ -1,0 +1,73 @@
+--- The mission authoring DSL builder: chain -> descriptor -> sink, the
+--- policy_builder idiom. Pure Lua, no Spring.
+---
+--- The surface is dot-only: every chain step is a plain call with parens —
+--- `T.When(cond).Then(fn).Register()` — no colon methods, no metatables.
+--- Chains are closures over a local descriptor, so the same file loads in the
+--- synced sandbox (which strips rawset) and in busted unchanged.
+---
+--- Trigger identity = filename + declaration order, stamped at Register —
+--- the key hot reload unregisters by.
+
+local DSL = {}
+
+---Build the `T` injected into one trigger file's environment. Declaration
+---order is per-file: the Nth Register call in the file is trigger N.
+---@param filename string mission-relative path, e.g. "triggers/win.lua"
+---@param sink fun(descriptor: TriggerDescriptor)
+---@return TriggerDSL
+function DSL.ForFile(filename, sink)
+	local order = 0
+
+	local T = {}
+
+	---@param condition MissionCondition
+	---@return TriggerChain
+	T.When = function(condition)
+		assert(type(condition) == "table" and type(condition.evaluate) == "function",
+			filename .. ": T.When expects a condition (a table with an evaluate function)")
+
+		local effect = nil ---@type nil|fun(ctx: MissionContext)
+		local once = true
+		local registered = false
+
+		local chain = {}
+
+		---@param fn fun(ctx: MissionContext)
+		---@return TriggerChain
+		chain.Then = function(fn)
+			assert(type(fn) == "function", filename .. ": Then expects a function")
+			assert(effect == nil, filename .. ": duplicate Then on one trigger")
+			effect = fn
+			return chain
+		end
+
+		---@param flag boolean?
+		---@return TriggerChain
+		chain.Once = function(flag)
+			once = flag ~= false
+			return chain
+		end
+
+		chain.Register = function()
+			assert(not registered, filename .. ": trigger registered twice")
+			assert(effect ~= nil, filename .. ": trigger needs a Then before Register")
+			registered = true
+			order = order + 1
+			sink({
+				id = filename .. ":" .. order,
+				filename = filename,
+				order = order,
+				condition = condition,
+				effect = effect,
+				once = once,
+			})
+		end
+
+		return chain
+	end
+
+	return T
+end
+
+return DSL

--- a/modules/missions/lib/trigger_engine.lua
+++ b/modules/missions/lib/trigger_engine.lua
@@ -1,0 +1,86 @@
+--- Mission trigger engine: holds registered triggers, evaluates their
+--- conditions on the caller's cadence, runs effects. Pure Lua — no Spring —
+--- so it specs under busted.
+---
+--- State discipline (the savegame rule, enforced from commit one): trigger
+--- progress — fired flags — lives in the engine's plain `state` table, never
+--- in closures. Definitions are the source pile; `state` is the save pile.
+
+local TriggerEngine = {}
+
+---@class MissionTriggerEngine
+---@field Register fun(descriptor: TriggerDescriptor)
+---@field UnregisterFile fun(filename: string): integer removed count
+---@field Evaluate fun(ctx: MissionContext)
+---@field Triggers fun(): TriggerDescriptor[] registration order, read-only by convention
+---@field GetState fun(): TriggerEngineState the serializable progress pile
+---@field SetState fun(state: TriggerEngineState) reapply saved progress over reloaded definitions
+
+---@return MissionTriggerEngine
+function TriggerEngine.New()
+	local triggers = {} ---@type TriggerDescriptor[]
+	local state = { fired = {} } ---@type TriggerEngineState
+
+	local engine = {}
+
+	---@param descriptor TriggerDescriptor
+	engine.Register = function(descriptor)
+		assert(type(descriptor.id) == "string", "trigger descriptor needs an id")
+		assert(type(descriptor.condition) == "table" and type(descriptor.condition.evaluate) == "function",
+			descriptor.id .. ": condition must have an evaluate function")
+		assert(type(descriptor.effect) == "function", descriptor.id .. ": effect must be a function")
+		for _, existing in ipairs(triggers) do
+			if existing.id == descriptor.id then
+				error("duplicate trigger id: " .. descriptor.id)
+			end
+		end
+		triggers[#triggers + 1] = descriptor
+	end
+
+	---Remove every trigger registered from `filename`, and its progress —
+	---the hot-reload half of unregister-by-identity.
+	---@param filename string
+	---@return integer removed
+	engine.UnregisterFile = function(filename)
+		local kept, removed = {}, 0
+		for _, trigger in ipairs(triggers) do
+			if trigger.filename == filename then
+				removed = removed + 1
+				state.fired[trigger.id] = nil
+			else
+				kept[#kept + 1] = trigger
+			end
+		end
+		triggers = kept
+		return removed
+	end
+
+	---@param ctx MissionContext
+	engine.Evaluate = function(ctx)
+		for _, trigger in ipairs(triggers) do
+			if not (trigger.once and state.fired[trigger.id]) and trigger.condition.evaluate(ctx) then
+				state.fired[trigger.id] = true
+				trigger.effect(ctx)
+			end
+		end
+	end
+
+	---@return TriggerDescriptor[]
+	engine.Triggers = function()
+		return triggers
+	end
+
+	---@return TriggerEngineState
+	engine.GetState = function()
+		return state
+	end
+
+	---@param saved TriggerEngineState
+	engine.SetState = function(saved)
+		state = saved
+	end
+
+	return engine
+end
+
+return TriggerEngine

--- a/modules/missions/lib/verbs.lua
+++ b/modules/missions/lib/verbs.lua
@@ -1,0 +1,46 @@
+--- The three demo verbs' pure halves: UnitDef refs and the Team handle with
+--- its Has condition. No Spring here — conditions read counts from the ctx the
+--- engine is handed, so this specs under busted; the gadget supplies a ctx
+--- backed by Spring.GetTeamUnitDefCount.
+---
+--- Conditions capture configuration only (team id, unit name, threshold) —
+--- never progress. Dot-only surface, same rule as the chain DSL.
+
+local Verbs = {}
+
+---@param name string unit def name, e.g. "armpw"
+---@return MissionUnitDefRef
+function Verbs.UnitDef(name)
+	assert(type(name) == "string", "UnitDef expects a unit def name string")
+	return { name = name }
+end
+
+---Build a Team handle for one team.
+---@param teamID integer
+---@param allyTeam integer
+---@return MissionTeam
+function Verbs.MakeTeam(teamID, allyTeam)
+	local team = {
+		teamID = teamID,
+		allyTeam = allyTeam,
+	}
+
+	---@param unitDef MissionUnitDefRef
+	---@param count integer
+	---@return MissionCondition
+	team.Has = function(unitDef, count)
+		assert(type(unitDef) == "table" and type(unitDef.name) == "string",
+			"Team.Has expects a UnitDef(...) reference")
+		assert(type(count) == "number", "Team.Has expects a count")
+		return {
+			---@param ctx MissionContext
+			evaluate = function(ctx)
+				return ctx.GetUnitDefCount(teamID, unitDef.name) >= count
+			end,
+		}
+	end
+
+	return team
+end
+
+return Verbs

--- a/modules/missions/types/missions.lua
+++ b/modules/missions/types/missions.lua
@@ -1,0 +1,55 @@
+--- Mission-runtime types: the trigger engine's descriptors and the authoring
+--- DSL's chain/condition shapes. The DSL surface is dot-only: every chain step
+--- is a plain call with parens, no colon methods, no metatables — mission files
+--- must load identically in the synced sandbox (which strips rawset) and in
+--- busted.
+
+--- A condition the trigger engine evaluates on its cadence. Pure: reads only
+--- the ctx it is handed; captures configuration (team ids, unit names), never
+--- progress. Progress lives in the engine's state tables (the savegame rule).
+---@class MissionCondition
+---@field evaluate fun(ctx: MissionContext): boolean
+
+--- What the engine hands every condition and effect. The gadget builds it from
+--- Spring; specs build it from plain tables.
+---@class MissionContext
+---@field GetUnitDefCount fun(teamID: integer, unitDefName: string): integer count of finished units of that def
+---@field frame integer current game frame
+
+--- A registered trigger. Identity = source filename + declaration order,
+--- stamped at registration — the unregister-by-identity key for hot reload.
+---@class TriggerDescriptor
+---@field id string "<filename>:<order>"
+---@field filename string mission-relative trigger file path
+---@field order integer 1-based declaration order within the file
+---@field condition MissionCondition
+---@field effect fun(ctx: MissionContext)
+---@field once boolean fire at most once (default true)
+
+--- The dot-only builder chain returned by T.When. Every step returns the
+--- chain; Register is the terminal and returns nothing.
+---@class TriggerChain
+---@field Then fun(effect: fun(ctx: MissionContext)): TriggerChain
+---@field Once fun(once: boolean?): TriggerChain default true; pass false for repeating triggers
+---@field Register fun()
+
+--- The `T` the loader injects into each trigger file's environment.
+---@class TriggerDSL
+---@field When fun(condition: MissionCondition): TriggerChain
+
+--- A unit-def reference produced by the injected UnitDef verb. Carries the
+--- name only; resolution to an id happens where Spring exists.
+---@class MissionUnitDefRef
+---@field name string
+
+--- The injected Team.Player handle. Demo rule: resolves to the first human
+--- team at mission load.
+---@class MissionTeam
+---@field teamID integer
+---@field allyTeam integer
+---@field Has fun(unitDef: MissionUnitDefRef, count: integer): MissionCondition
+
+--- Serializable trigger progress: the pile a checkpoint saves. Definitions
+--- reload from source; this table is reapplied on top.
+---@class TriggerEngineState
+---@field fired table<string, boolean> trigger id -> has fired

--- a/modules/module_handler.lua
+++ b/modules/module_handler.lua
@@ -1,0 +1,473 @@
+--- Encapsulated game modules: discovery, contracts, and auto-registration.
+---
+--- A module is a directory under modules/ with opinionated subdirectories:
+---   widgets/               unsynced widgets, auto-loaded (luaui/barwidgets.lua)
+---   rml_widgets/           RmlUi widgets, auto-loaded (luaui/barwidgets.lua)
+---   gadgets/               gadgets, auto-loaded (luarules/gadgets.lua)
+---   actions/               one file per action returning an ActionDescriptor
+---   policies/<category>/   one file per policy returning a PolicyDescriptor;
+---                          evaluated in filename order (use numeric prefixes)
+---   modes/                 declarative ModeConfig presets
+---   lib/                   shared pure code
+---   economy/, types/, spec/ ...
+---
+--- An optional module.lua manifest (ModuleManifest) declares version, requires
+--- and provides; a directory with any auto-loaded subdirectory is discovered as
+--- a module even without one. Plain shared-lib directories (modules/i18n,
+--- modules/graphics) have none of those subdirectories and are left alone.
+---
+--- Game-side loading is the shim for engine-native module loading (Recoil RFC);
+--- the layout is the contract, this file is the reference implementation.
+--- There is deliberately NO game-side include cache: VFS.Include is uncached in
+--- the engine, and a per-handler cache would only pretend otherwise (this file
+--- is itself re-included per consumer). Registries and contracts are memoized
+--- per handler; true load-once-per-state is the engine RFC's require().
+
+local LOG_TAG = "module_handler.lua"
+
+local PolicyBuilder = VFS.Include("modules/policy_builder.lua")
+
+local MODULES_DIR = "modules/"
+
+-- Subdirectories that mark a directory as a module even without a manifest.
+local MODULE_MARKERS = { "widgets", "rml_widgets", "gadgets", "actions", "policies" }
+
+local ModuleHandler = {}
+
+---Log an error via Spring when available; modoptions.lua pulls this file into
+---lobby/unitsync LuaParser contexts where the Spring global does not exist.
+---@param message string
+local function logError(message)
+	---@diagnostic disable-next-line: unnecessary-if -- Spring IS nil in lobby LuaParser; the analyzer can't know
+	if Spring and Spring.Log then
+		Spring.Log(LOG_TAG, LOG and LOG.ERROR or "error", message)
+	else
+		print("[" .. LOG_TAG .. "] ERROR: " .. message)
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Discovery
+--------------------------------------------------------------------------------
+
+---@param dir string directory with trailing slash
+---@return string name
+local function dirBasename(dir)
+	return dir:gsub("/+$", ""):match("([^/]+)$") --[[@as string]]
+end
+
+---Native VFS.SubDirs returns entries with a trailing slash; keep any source normalized.
+---@param dir string
+---@return string
+local function ensureSlash(dir)
+	if dir:sub(-1) ~= "/" then
+		return dir .. "/"
+	end
+	return dir
+end
+
+---@param moduleDir string
+---@param vfsMode string?
+---@return boolean
+local function hasModuleMarker(moduleDir, vfsMode)
+	for _, marker in ipairs(MODULE_MARKERS) do
+		local sub = moduleDir .. marker .. "/"
+		if #VFS.DirList(sub, "*", vfsMode) > 0 or #VFS.SubDirs(sub, "*", vfsMode) > 0 then
+			return true
+		end
+	end
+	return false
+end
+
+---@param moduleDir string
+---@param vfsMode string?
+---@return ModuleManifest|nil
+local function loadManifest(moduleDir, vfsMode)
+	local name = dirBasename(moduleDir)
+	local manifestPath = moduleDir .. "module.lua"
+	---@type ModuleManifestFile
+	local manifest
+	if VFS.FileExists(manifestPath, vfsMode) then
+		manifest = VFS.Include(manifestPath, nil, vfsMode)
+		if type(manifest) ~= "table" or type(manifest.name) ~= "string" then
+			logError("Invalid module manifest (missing name): " .. manifestPath)
+			return nil
+		end
+		if manifest.name ~= name then
+			logError(string.format("Module manifest name %q does not match directory %q", manifest.name, name))
+			return nil
+		end
+	elseif hasModuleMarker(moduleDir, vfsMode) then
+		-- Implicit manifest: a bare directory with auto-loaded subdirectories.
+		manifest = { name = name }
+	else
+		return nil
+	end
+	---@cast manifest ModuleManifest
+	manifest.dir = moduleDir
+	manifest.requires = manifest.requires or {}
+	return manifest
+end
+
+local manifestsCache = nil ---@type table<string, ModuleManifest>|nil
+
+---Discover all modules. Cached after the first call.
+---@param vfsMode string?
+---@return table<string, ModuleManifest> manifests keyed by module name
+function ModuleHandler.Discover(vfsMode)
+	if manifestsCache then
+		return manifestsCache
+	end
+	local manifests = {}
+	for _, moduleDir in ipairs(VFS.SubDirs(MODULES_DIR, "*", vfsMode)) do
+		local manifest = loadManifest(ensureSlash(moduleDir), vfsMode)
+		if manifest then
+			manifests[manifest.name] = manifest
+		end
+	end
+	for name, manifest in pairs(manifests) do
+		for _, required in ipairs(manifest.requires) do
+			if not manifests[required] then
+				logError(string.format("Module %q requires missing module %q", name, required))
+			end
+		end
+	end
+	manifestsCache = manifests
+	return manifests
+end
+
+---The current Lua state. Only the synced LuaRules/LuaGaia VM has SendToUnsynced;
+---LuaUI/LuaMenu and the unsynced gadget state resolve as "unsynced".
+---@return "synced"|"unsynced"
+local function currentState()
+	return (SendToUnsynced ~= nil) and "synced" or "unsynced"
+end
+
+local apiCache = {}
+
+---Resolve a module's public contract for the current Lua state.
+---
+---The manifest declares the partition explicitly — provides as a plain path
+---(state-agnostic) or { shared = path, synced = path, unsynced = path } —
+---and resolution merges implicitly: consumers hold one flat api holding
+---exactly the surface that exists where they stand (state keys win over
+---shared on collision). A widget never sees synced-only keys, and vice
+---versa; wrong-state access is nil at the first index, not a crash later.
+---@param name string
+---@param vfsMode string?
+---@return table|nil api
+function ModuleHandler.Get(name, vfsMode)
+	local state = currentState()
+	local cacheKey = name .. "|" .. state
+	if apiCache[cacheKey] then
+		return apiCache[cacheKey]
+	end
+
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	if not manifest then
+		logError("Unknown module: " .. tostring(name))
+		return nil
+	end
+
+	local provides = manifest.provides
+	local parts = {}
+	if type(provides) == "table" then
+		parts[#parts + 1] = provides.shared
+		parts[#parts + 1] = provides[state]
+	else
+		parts[1] = provides or (manifest.dir .. "api.lua")
+	end
+
+	local api = {}
+	local resolved = 0
+	for _, path in ipairs(parts) do
+		if VFS.FileExists(path, vfsMode) then
+			local part = VFS.Include(path, nil, vfsMode)
+			if type(part) ~= "table" then
+				logError(string.format("Module %q contract must return a table: %s", name, path))
+			else
+				for key, value in pairs(part) do
+					api[key] = value
+				end
+				resolved = resolved + 1
+			end
+		else
+			logError(string.format("Module %q contract file not found: %s", name, path))
+		end
+	end
+	if resolved == 0 then
+		logError(string.format("Module %q provides nothing in %s state", name, state))
+		return nil
+	end
+
+	apiCache[cacheKey] = api
+	return api
+end
+
+--------------------------------------------------------------------------------
+-- Auto-loaded subdirectories (consumed by luarules/gadgets.lua, luaui/barwidgets.lua)
+--------------------------------------------------------------------------------
+
+---@param subdir string e.g. "widgets/"
+---@param vfsMode string?
+---@return string[] dirs
+local function moduleSubdirs(subdir, vfsMode)
+	local dirs = {}
+	for _, manifest in pairs(ModuleHandler.Discover(vfsMode)) do
+		local dir = manifest.dir .. subdir
+		if #VFS.DirList(dir, "*.lua", vfsMode) > 0 or #VFS.SubDirs(dir, "*", vfsMode) > 0 then
+			dirs[#dirs + 1] = dir
+		end
+	end
+	table.sort(dirs)
+	return dirs
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.WidgetDirs(vfsMode)
+	return moduleSubdirs("widgets/", vfsMode)
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.RmlWidgetDirs(vfsMode)
+	return moduleSubdirs("rml_widgets/", vfsMode)
+end
+
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.GadgetDirs(vfsMode)
+	return moduleSubdirs("gadgets/", vfsMode)
+end
+
+---Mode-preset directories contributed by modules ("surrogate modes": presets
+---travel with the module that owns the modoptions they lock; the root modes/
+---system aggregates them).
+---@param vfsMode string?
+---@return string[]
+function ModuleHandler.ModeDirs(vfsMode)
+	return moduleSubdirs("modes/", vfsMode)
+end
+
+--------------------------------------------------------------------------------
+-- Actions: registration-style, one file per action, identity = filename.
+-- The loader injects `Actions` into each file's environment (the widget-handler
+-- idiom: an explicit named Register call on an explicit local — NOT anonymous
+-- setfenv globals, which is the fragility dbg_test_runner migrated away from).
+-- Files register and return nothing; the runtime descriptor is assembled here,
+-- never hand-authored. Runtime parameter schemas return, derived from the
+-- LuaCATS annotations (single-sourced), if/when a data-driven dispatcher
+-- (mission_api, CampaignAPI) creates a boundary the type checker cannot see.
+--------------------------------------------------------------------------------
+
+---@param filePath string
+---@return string
+local function nameFromFile(filePath)
+	return filePath:match("([^/]+)%.lua$") --[[@as string]]
+end
+
+-- Base environment for registration files: this chunk's own environment, so
+-- injected files see exactly what this file sees (VFS, Spring, ...). The
+-- synced state defines _G; unsynced widget sandboxes may not, so fall back
+-- to getfenv (kept in unsynced). Discovered via headless smoke: __index = _G
+-- alone left action files without VFS in the widget path.
+---@type table
+local CHUNK_ENV = _G
+if CHUNK_ENV == nil or CHUNK_ENV.VFS == nil then
+	local ok, env = pcall(getfenv, 1)
+	if ok and env ~= nil then
+		CHUNK_ENV = env
+	end
+end
+
+---Include a registration file with names injected into its environment.
+---Deliberately UNCACHED: registration must re-fire per include. The engine's
+---VFS.Include is uncached by nature; the busted shim only caches truthy
+---returns, and registration files return nothing.
+---@param filePath string
+---@param injected table
+---@param vfsMode string?
+---@return any returned whatever the file returned (must be nil)
+local function includeRegistrationFile(filePath, injected, vfsMode)
+	local env = setmetatable(injected, { __index = CHUNK_ENV })
+	return VFS.Include(filePath, env, vfsMode)
+end
+
+local actionsCache = {}
+
+---Load a module's actions/ directory: bracketed registration per file.
+---@param name string module name
+---@param vfsMode string?
+---@return {byName: table<string, ActionDescriptor>, list: ActionDescriptor[]}
+function ModuleHandler.LoadActions(name, vfsMode)
+	if actionsCache[name] then
+		return actionsCache[name]
+	end
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	local registry = { byName = {}, list = {} }
+	if not manifest then
+		logError("LoadActions: unknown module " .. tostring(name))
+		return registry
+	end
+	local files = VFS.DirList(manifest.dir .. "actions/", "*.lua", vfsMode)
+	table.sort(files)
+	for _, filePath in ipairs(files) do
+		local actionName = nameFromFile(filePath)
+		local entry = { name = actionName }
+		---@cast entry ActionDescriptor -- execute arrives via RegisterExecute; enforced below
+		local registrar = {
+			---@param fn function pure precondition; must precede RegisterExecute
+			RegisterValidate = function(fn)
+				if type(fn) ~= "function" then
+					error(filePath .. ": Actions.RegisterValidate expects a function")
+				end
+				if entry.execute ~= nil then
+					error(filePath .. ": RegisterValidate must precede RegisterExecute")
+				end
+				if entry.validate ~= nil then
+					error(filePath .. ": duplicate RegisterValidate")
+				end
+				entry.validate = fn
+			end,
+			---@param fn function the only effectful code; exactly one per file
+			RegisterExecute = function(fn)
+				if type(fn) ~= "function" then
+					error(filePath .. ": Actions.RegisterExecute expects a function")
+				end
+				if entry.execute ~= nil then
+					error(filePath .. ": duplicate RegisterExecute — exactly one per action file")
+				end
+				entry.execute = fn
+			end,
+		}
+		local returned = includeRegistrationFile(filePath, { Actions = registrar }, vfsMode)
+		if returned ~= nil then
+			error(filePath .. ": action files register, they do not return (old descriptor style?)")
+		end
+		if entry.execute == nil then
+			error(filePath .. ": no Actions.RegisterExecute — every action must register execute")
+		end
+		registry.byName[actionName] = entry
+		registry.list[#registry.list + 1] = entry
+	end
+	actionsCache[name] = registry
+	return registry
+end
+
+--------------------------------------------------------------------------------
+-- Policies: registration-style, one pipeline per category, identity = filename.
+-- The loader injects `Policies` (a Pipeline facade bound to this file's sink);
+-- files end with :Register() and return nothing. Stage order is declaration
+-- order; the first non-nil result wins; the Compute terminal always returns.
+--------------------------------------------------------------------------------
+
+local policiesCache = {}
+
+---Load a module's policies/ directory into per-category ordered stage lists.
+---@param name string module name
+---@param vfsMode string?
+---@return table<string, PolicyDescriptor[]> pipelines keyed by category (filename)
+function ModuleHandler.LoadPolicies(name, vfsMode)
+	if policiesCache[name] then
+		return policiesCache[name]
+	end
+	local manifest = ModuleHandler.Discover(vfsMode)[name]
+	local byCategory = {}
+	if not manifest then
+		logError("LoadPolicies: unknown module " .. tostring(name))
+		return byCategory
+	end
+	local files = VFS.DirList(manifest.dir .. "policies/", "*.lua", vfsMode)
+	table.sort(files)
+	for _, filePath in ipairs(files) do
+		local category = nameFromFile(filePath)
+		local registered = nil
+		local facade = {
+			Pipeline = function()
+				local builder = PolicyBuilder.Pipeline()
+				builder._sink = function(stages)
+					if registered ~= nil then
+						error(filePath .. ": duplicate pipeline registration")
+					end
+					for _, stage in ipairs(stages) do
+						stage.category = stage.category or category
+					end
+					registered = stages
+				end
+				return builder
+			end,
+		}
+		local returned = includeRegistrationFile(filePath, { Policies = facade }, vfsMode)
+		if returned ~= nil then
+			error(filePath .. ": policy files register, they do not return (end with :Register())")
+		end
+		if registered == nil then
+			error(filePath .. ": no pipeline registered — end with :Register()")
+		end
+		byCategory[category] = registered
+	end
+	policiesCache[name] = byCategory
+	return byCategory
+end
+
+---Evaluate an ordered policy list: the first non-nil result wins.
+---By convention the last policy (the 1xx_compute_* file) always returns.
+---@generic R
+---@param policies PolicyDescriptor[]
+---@param ... any arguments passed to each policy's evaluate
+---@return R|nil result nil only if no policy produced a result
+function ModuleHandler.Evaluate(policies, ...)
+	for _, policy in ipairs(policies) do
+		local result = policy.evaluate(...)
+		if result ~= nil then
+			return result
+		end
+	end
+	return nil
+end
+
+--------------------------------------------------------------------------------
+-- Mod options: modules ship their own modoptions.lua fragment, merged into the
+-- game's modoptions.lua (same entry format; append order = module-name order)
+--------------------------------------------------------------------------------
+
+---Collect module-contributed modoption entries.
+---@param vfsMode string?
+---@return table[] options
+function ModuleHandler.ModOptions(vfsMode)
+	local names = {}
+	for name in pairs(ModuleHandler.Discover(vfsMode)) do
+		names[#names + 1] = name
+	end
+	table.sort(names)
+
+	local options = {}
+	for _, name in ipairs(names) do
+		local manifest = ModuleHandler.Discover(vfsMode)[name]
+		local fragmentPath = manifest.dir .. "modoptions.lua"
+		if VFS.FileExists(fragmentPath, vfsMode) then
+			local fragment = VFS.Include(fragmentPath, nil, vfsMode)
+			if type(fragment) ~= "table" then
+				logError("Module modoptions fragment must return a list: " .. fragmentPath)
+			else
+				for _, option in ipairs(fragment) do
+					options[#options + 1] = option
+				end
+			end
+		end
+	end
+	return options
+end
+
+--------------------------------------------------------------------------------
+
+---Testing hook: reset discovery + include caches.
+function ModuleHandler.ResetCaches()
+	manifestsCache = nil
+	apiCache = {}
+	actionsCache = {}
+	policiesCache = {}
+end
+
+return ModuleHandler

--- a/modules/policy_builder.lua
+++ b/modules/policy_builder.lua
@@ -1,0 +1,82 @@
+--- Fluent builder that emits PolicyDescriptors — no runtime of its own.
+---
+--- The canonical policy format is the category file (see modules/types/modules.lua):
+--- modules/<name>/policies/<category>.lua registers an ordered PolicyDescriptor[]
+--- and returns nothing. Pipeline() is how those files read — gates in declaration
+--- order, one terminal compute — and what it hands the loader is a plain
+--- descriptor list, byte-for-byte equivalent to writing the tables by hand:
+---
+---   Policies.Pipeline()
+---       :Gate("SharingEnabled", function(ctx, resourceType) ... end)
+---       :Compute("ComputeResourceTransfer", function(ctx, resourceType) ... end)
+---       :Register()
+---
+--- Register() is the terminal for category files. Build() returns the descriptor
+--- list instead, for programmatic pipelines and specs.
+
+local PolicyBuilder = {}
+
+---@class PolicyPipeline
+---@field stages PolicyDescriptor[]
+---@field computed boolean
+---@field _sink (fun(stages: PolicyDescriptor[]))|nil bound by the loader's Policies facade
+local PolicyPipeline = {}
+PolicyPipeline.__index = PolicyPipeline
+
+---One ordered pipeline per category file. Order is declaration order — the
+---framework evaluates stages top to bottom, first result wins.
+---@return PolicyPipeline
+---Category is NOT an argument: the pipeline's identity is its filename
+---(policies/<category>.lua) and ModuleHandler.LoadPolicies stamps it — one
+---source of truth, no magic strings to drift.
+function PolicyBuilder.Pipeline()
+	return setmetatable({
+		stages = {},
+		computed = false,
+	}, PolicyPipeline)
+end
+
+---A gate: return a result to end evaluation (usually a deny), nil to pass.
+---@param name string
+---@param evaluate fun(...): any
+---@return PolicyPipeline
+function PolicyPipeline:Gate(name, evaluate)
+	assert(not self.computed, "PolicyPipeline: Gate() after Compute() — the terminal must be last")
+	self.stages[#self.stages + 1] = {
+		name = name,
+		evaluate = evaluate,
+	}
+	return self
+end
+
+---The terminal: always returns a result. Exactly one, and last.
+---@param name string
+---@param evaluate fun(...): any
+---@return PolicyPipeline
+function PolicyPipeline:Compute(name, evaluate)
+	assert(not self.computed, "PolicyPipeline: only one Compute() per pipeline")
+	self.computed = true
+	self.stages[#self.stages + 1] = {
+		name = name,
+		evaluate = evaluate,
+	}
+	return self
+end
+
+---@return PolicyDescriptor[]
+function PolicyPipeline:Build()
+	assert(self.computed, "PolicyPipeline: a pipeline needs a terminal Compute()")
+	return self.stages
+end
+
+---Terminal for policies/<category>.lua files: hand the built stage list to
+---the loader's sink (injected by ModuleHandler.LoadPolicies). Registration
+---style, one idiom framework-wide: files register, they do not return.
+function PolicyPipeline:Register()
+	if self._sink == nil then
+		error("PolicyPipeline:Register() outside a policies/ loader bracket — use :Build() for programmatic pipelines")
+	end
+	self._sink(self:Build())
+end
+
+return PolicyBuilder

--- a/modules/types/modules.lua
+++ b/modules/types/modules.lua
@@ -1,0 +1,45 @@
+--- What a module author writes in modules/<name>/module.lua.
+---@class ModuleManifestFile
+---@field name string Module name; must match its directory under modules/
+---@field version string|nil Semver-ish version string
+---@field description string|nil One-line description
+---@field requires string[]|nil Names of modules this module depends on
+---@field provides string|table|nil Public contract: a path (state-agnostic, default <dir>/api.lua) or an explicit partition { shared = path, synced = path, unsynced = path }; ModuleHandler.Get merges shared + current state into one flat api
+
+--- A discovered manifest, enriched by the loader.
+---@class ModuleManifest : ModuleManifestFile
+---@field dir string Module directory with trailing slash (loader-stamped)
+
+--- The runtime registry entry for an action — assembled by the LOADER, never
+--- hand-authored. Action files register via the injected `Actions` registrar
+--- (`local Actions = Actions`, the widget-handler idiom: explicit named calls
+--- on an explicit local, not anonymous setfenv globals): RegisterValidate
+--- (optional, first) then RegisterExecute (required, exactly one); files
+--- return nothing, and identity is the filename (actions/unit_transfer.lua →
+--- "unit_transfer"). Actions are the only effectful layer; validate stays pure.
+--- NOTE: no hand-written parameter schema — controllers are statically typed
+--- (LuaCATS + emmylua). A DERIVED schema (generated from the annotations, e.g.
+--- lua-doc-extractor) returns if/when a data-driven dispatcher (mission_api,
+--- CampaignAPI) creates a runtime boundary the type checker cannot see.
+---@class ActionDescriptor
+---@field name string From the filename; loader-stamped
+---@field validate function|nil Pure precondition check over the action's inputs (no mutation)
+---@field execute function Performs the action
+
+---@class ActionRegistrar
+---@field RegisterValidate fun(fn: function)
+---@field RegisterExecute fun(fn: function)
+
+---@class PoliciesRegistrar
+---@field Pipeline fun(): PolicyPipeline
+
+--- One pipeline per category: modules/<name>/policies/<category>.lua registers
+--- an ordered PolicyDescriptor[] via the injected `Policies` facade —
+--- Policies.Pipeline():Gate(...):Compute(...):Register(); files return nothing. Pure functions constrained by types: no engine mutation in
+--- evaluate. Stages run in declaration order; returning nil passes to the next
+--- stage, returning a result ends evaluation (first result wins). The terminal
+--- Compute stage always returns.
+---@class PolicyDescriptor
+---@field name string
+---@field category string|nil Defaults to the policies/<category>.lua filename
+---@field evaluate function fun(...): result|nil

--- a/spec/modules/missions/dsl_spec.lua
+++ b/spec/modules/missions/dsl_spec.lua
@@ -1,0 +1,90 @@
+local DSL = VFS.Include("modules/missions/lib/dsl.lua")
+local Verbs = VFS.Include("modules/missions/lib/verbs.lua")
+
+local alwaysTrue = { evaluate = function() return true end }
+
+describe("mission DSL", function()
+	local registered ---@type TriggerDescriptor[]
+	local T ---@type TriggerDSL
+
+	before_each(function()
+		registered = {}
+		T = DSL.ForFile("triggers/win.lua", function(descriptor)
+			registered[#registered + 1] = descriptor
+		end)
+	end)
+
+	it("builds a descriptor from a dot-only chain", function()
+		local effect = function() end
+		T.When(alwaysTrue).Then(effect).Register()
+
+		assert.are.equal(1, #registered)
+		local descriptor = registered[1]
+		assert.are.equal("triggers/win.lua:1", descriptor.id)
+		assert.are.equal("triggers/win.lua", descriptor.filename)
+		assert.are.equal(1, descriptor.order)
+		assert.are.equal(alwaysTrue, descriptor.condition)
+		assert.are.equal(effect, descriptor.effect)
+		assert.is_true(descriptor.once)
+	end)
+
+	it("stamps declaration order per file", function()
+		T.When(alwaysTrue).Then(function() end).Register()
+		T.When(alwaysTrue).Then(function() end).Register()
+		assert.are.equal("triggers/win.lua:1", registered[1].id)
+		assert.are.equal("triggers/win.lua:2", registered[2].id)
+	end)
+
+	it("defaults Once to true and honors Once(false)", function()
+		T.When(alwaysTrue).Then(function() end).Once(false).Register()
+		assert.is_false(registered[1].once)
+	end)
+
+	it("requires a Then before Register", function()
+		assert.has_error(function()
+			T.When(alwaysTrue).Register()
+		end)
+	end)
+
+	it("rejects a second Register on the same chain", function()
+		local chain = T.When(alwaysTrue).Then(function() end)
+		chain.Register()
+		assert.has_error(function()
+			chain.Register()
+		end)
+	end)
+
+	it("rejects a condition without evaluate", function()
+		assert.has_error(function()
+			T.When({})
+		end)
+	end)
+end)
+
+describe("mission verbs", function()
+	it("UnitDef carries the name", function()
+		assert.are.same({ name = "armpw" }, Verbs.UnitDef("armpw"))
+	end)
+
+	it("Team.Has evaluates against ctx counts", function()
+		local team = Verbs.MakeTeam(0, 0)
+		local condition = team.Has(Verbs.UnitDef("armpw"), 3)
+
+		local counts = { [0] = { armpw = 2 } }
+		local ctx = {
+			frame = 0,
+			GetUnitDefCount = function(teamID, defName)
+				return (counts[teamID] or {})[defName] or 0
+			end,
+		}
+		assert.is_false(condition.evaluate(ctx))
+		counts[0].armpw = 3
+		assert.is_true(condition.evaluate(ctx))
+	end)
+
+	it("Team carries teamID and allyTeam for MatchFlow calls", function()
+		local team = Verbs.MakeTeam(2, 1)
+		assert.are.equal(2, team.teamID)
+		assert.are.equal(1, team.allyTeam)
+	end)
+end)

--- a/spec/modules/missions/trigger_engine_spec.lua
+++ b/spec/modules/missions/trigger_engine_spec.lua
@@ -1,0 +1,129 @@
+local TriggerEngine = VFS.Include("modules/missions/lib/trigger_engine.lua")
+
+---@param counts table<integer, table<string, integer>> teamID -> defName -> count
+---@param frame integer?
+---@return MissionContext
+local function makeCtx(counts, frame)
+	return {
+		frame = frame or 0,
+		GetUnitDefCount = function(teamID, defName)
+			return (counts[teamID] or {})[defName] or 0
+		end,
+	}
+end
+
+---@param id string
+---@param result boolean|fun(ctx: MissionContext): boolean
+---@param log string[]
+---@return TriggerDescriptor
+local function makeTrigger(id, result, log)
+	return {
+		id = id,
+		filename = id:match("^(.*):") or id,
+		order = tonumber(id:match(":(%d+)$")) or 1,
+		condition = {
+			evaluate = function(ctx)
+				if type(result) == "function" then
+					return result(ctx)
+				end
+				return result
+			end,
+		},
+		effect = function()
+			log[#log + 1] = id
+		end,
+		once = true,
+	}
+end
+
+describe("TriggerEngine", function()
+	it("runs an effect when its condition holds", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("does not run an effect while its condition is false", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", false, log))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	it("fires a once trigger at most once", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1" }, log)
+	end)
+
+	it("fires a repeating trigger every evaluation", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		local trigger = makeTrigger("f.lua:1", true, log)
+		trigger.once = false
+		engine.Register(trigger)
+		engine.Evaluate(makeCtx({}))
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({ "f.lua:1", "f.lua:1" }, log)
+	end)
+
+	it("rejects duplicate trigger ids", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		assert.has_error(function()
+			engine.Register(makeTrigger("f.lua:1", true, log))
+		end)
+	end)
+
+	it("keeps fired flags in the engine state table, not closures", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.Evaluate(makeCtx({}))
+		assert.is_true(engine.GetState().fired["f.lua:1"])
+	end)
+
+	it("restores progress via SetState: a restored fired flag suppresses the effect", function()
+		local engine = TriggerEngine.New()
+		local log = {}
+		engine.Register(makeTrigger("f.lua:1", true, log))
+		engine.SetState({ fired = { ["f.lua:1"] = true } })
+		engine.Evaluate(makeCtx({}))
+		assert.are.same({}, log)
+	end)
+
+	describe("UnregisterFile", function()
+		it("removes exactly that file's triggers and their progress", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Register(makeTrigger("b.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+
+			local removed = engine.UnregisterFile("a.lua")
+			assert.are.equal(1, removed)
+			assert.is_nil(engine.GetState().fired["a.lua:1"])
+			assert.is_true(engine.GetState().fired["b.lua:1"])
+			assert.are.equal(1, #engine.Triggers())
+			assert.are.equal("b.lua:1", engine.Triggers()[1].id)
+		end)
+
+		it("lets a re-registered trigger fire again (hot reload)", function()
+			local engine = TriggerEngine.New()
+			local log = {}
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			engine.UnregisterFile("a.lua")
+			engine.Register(makeTrigger("a.lua:1", true, log))
+			engine.Evaluate(makeCtx({}))
+			assert.are.same({ "a.lua:1", "a.lua:1" }, log)
+		end)
+	end)
+end)


### PR DESCRIPTION
The runnable Hello Pawns demo from the campaign-API plan: six lines of mission Lua win a skirmish, authored in the trigger DSL, loaded by chat command, verified end to end in the headless harness.

The whole mission (`modules/missions/hello_pawns/triggers/win.lua`):

```lua
T.When(Team.Player.Has(UnitDef("armpw"), 3))
	.Then(function()
		Objective("build_pawns").Complete()
		MatchFlow.Victory(Team.Player.allyTeam)
	end)
	.Register()
```

## What's here

- **Loader bootstrap borrowed from the modules branch** — `module_handler.lua`, `policy_builder.lua`, `modules/types/`, plus minimal wiring (a 9-line module-gadget shim in `gadgets.lua`, 3 test-sandbox lines in `dbg_test_runner`). The borrow stayed small — this doubles as the master bootstrap step of the matchflow module plan.
- **Trigger engine** (`modules/missions/lib/trigger_engine.lua`) — pure Lua, busted-spec'd. Trigger identity = filename + declaration order; fired flags live in the engine's plain state tables (`GetState`/`SetState`), never in closures — the savegame rule from commit one. `UnregisterFile` is the hot-reload path.
- **Dot-only authoring DSL** (`lib/dsl.lua`, `lib/verbs.lua`) — every chain step is a plain call with parens, no colon calls, no metatables on the mission-facing surface. Chain → descriptor → sink, the policy_builder idiom.
- **matchflow, demo-minimal** — the scripted-verdict path only (`MatchFlow.Victory/Defeat` → verdict gadget → `Spring.GameOver`). The call shape is the contract; the real module (game_end extraction) lands underneath it later. Coexists with game_end the way missions do today — demo-only, not multiplayer-safe.
- **mission_loader gadget** — `/luarules mission hello_pawns` loads `triggers/*.lua` with an injected env of exactly `T, Team, UnitDef, Objective, MatchFlow`; the sandbox is the API surface. Evaluates every 15 frames. `Team.Player` = first human team (demo rule). `/luarules mission reload` exists but is untested.
- **Three verbs, no more**: `Team.Player.Has(unitDef, n)` (n *completed* units — nanoframes don't count, with an integration-test case proving a factory blueprint can't win the mission), `Objective(name).Complete()` (echo + rulesparam, no UI), `MatchFlow.Victory/Defeat`.

## Testing

- 18 busted specs for the engine/DSL/verbs (`spec/modules/missions/`), suite green.
- `luaui/Tests/hello_pawns/test_win.lua` plays the mission for real under the headless harness (`just bar::integrations`): arms it via the chat command, spawns two Pawns plus a nanoframe, asserts no verdict across two cadences, completes the frame, expects `GameOver` with the player's ally team. Suite: 0 failures.
- Not covered: the visual win screen in a real skirmish, and the reload command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)